### PR TITLE
[#88] 견적서 기능 개선 작업

### DIFF
--- a/src/main/java/com/carumuch/capstone/bidding/application/BiddingService.java
+++ b/src/main/java/com/carumuch/capstone/bidding/application/BiddingService.java
@@ -62,7 +62,7 @@ public class BiddingService {
         // 견적서를 공개에서 비공개로 전환
         Estimate estimate = estimateRepository.findById(bid.getEstimate().getId())
                 .orElseThrow(() -> new CustomException(RESOURCE_NOT_FOUND));
-        estimate.updateStatus(EstimateStatus.PRIVATE);
+        estimate.changeStatus(EstimateStatus.PRIVATE);
         return bid.getId();
     }
 }

--- a/src/main/java/com/carumuch/capstone/bidding/application/BiddingService.java
+++ b/src/main/java/com/carumuch/capstone/bidding/application/BiddingService.java
@@ -62,7 +62,7 @@ public class BiddingService {
         // 견적서를 공개에서 비공개로 전환
         Estimate estimate = estimateRepository.findById(bid.getEstimate().getId())
                 .orElseThrow(() -> new CustomException(RESOURCE_NOT_FOUND));
-        estimate.update(EstimateStatus.PRIVATE);
+        estimate.updateStatus(EstimateStatus.PRIVATE);
         return bid.getId();
     }
 }

--- a/src/main/java/com/carumuch/capstone/common/domain/AccessPolicy.java
+++ b/src/main/java/com/carumuch/capstone/common/domain/AccessPolicy.java
@@ -1,7 +1,5 @@
 package com.carumuch.capstone.common.domain;
 
-import com.carumuch.capstone.identity.domain.user.User;
-
 public interface AccessPolicy {
-	boolean canAccess(User user);
+	boolean canAccess(Long userId);
 }

--- a/src/main/java/com/carumuch/capstone/common/domain/AccessPolicy.java
+++ b/src/main/java/com/carumuch/capstone/common/domain/AccessPolicy.java
@@ -1,0 +1,7 @@
+package com.carumuch.capstone.common.domain;
+
+import com.carumuch.capstone.identity.domain.user.User;
+
+public interface AccessPolicy {
+	boolean canAccess(User user);
+}

--- a/src/main/java/com/carumuch/capstone/common/exception/ForbiddenException.java
+++ b/src/main/java/com/carumuch/capstone/common/exception/ForbiddenException.java
@@ -1,0 +1,9 @@
+package com.carumuch.capstone.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class ForbiddenException extends CustomException{
+	public ForbiddenException() {
+		super(HttpStatus.FORBIDDEN, "접근 권한이 없습니다.");
+	}
+}

--- a/src/main/java/com/carumuch/capstone/common/infrastructure/config/QueryDslConfig.java
+++ b/src/main/java/com/carumuch/capstone/common/infrastructure/config/QueryDslConfig.java
@@ -1,0 +1,21 @@
+package com.carumuch.capstone.common.infrastructure.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@RequiredArgsConstructor
+public class QueryDslConfig {
+	private final EntityManager entityManager;
+
+	@Bean
+	public JPAQueryFactory jpaQueryFactory() {
+		return new JPAQueryFactory(entityManager);
+	}
+}
+

--- a/src/main/java/com/carumuch/capstone/common/infrastructure/config/SecurityConfig.java
+++ b/src/main/java/com/carumuch/capstone/common/infrastructure/config/SecurityConfig.java
@@ -103,6 +103,7 @@ public class SecurityConfig {
 
 					.requestMatchers(
 						mvc.matcher(GET, ESTIMATE_URI + "/{estimateId}"),
+						mvc.matcher(GET, ESTIMATE_URI),
 						mvc.matcher(PUT, ESTIMATE_URI + "/{estimateId}/status")
 					).authenticated()
 

--- a/src/main/java/com/carumuch/capstone/common/infrastructure/config/SecurityConfig.java
+++ b/src/main/java/com/carumuch/capstone/common/infrastructure/config/SecurityConfig.java
@@ -36,6 +36,7 @@ public class SecurityConfig {
 	private static final String AUTH_URI = "/auth";
 	private static final String VEHICLE_URI = "/vehicles";
 	private static final String DAMAGE_REPORT_URI = "/damage-reports";
+	private static final String ESTIMATE_URI = "/estimates";
 	private static final String[] SWAGGER_PATTERNS = {"/swagger-ui/**", "/v3/api-docs/**", "/static/swagger-ui/**"};
 
     private final JwtAuthorizationFilter jwtAuthorizationFilter;
@@ -98,6 +99,10 @@ public class SecurityConfig {
 						mvc.matcher(POST, DAMAGE_REPORT_URI),
 						mvc.matcher(PUT, DAMAGE_REPORT_URI + "/{damageReportId}"),
 						mvc.matcher(GET, DAMAGE_REPORT_URI + "/recent")
+					).authenticated()
+
+					.requestMatchers(
+						mvc.matcher(GET, ESTIMATE_URI + "/{estimateId}")
 					).authenticated()
 
 					.anyRequest().permitAll()

--- a/src/main/java/com/carumuch/capstone/common/infrastructure/config/SecurityConfig.java
+++ b/src/main/java/com/carumuch/capstone/common/infrastructure/config/SecurityConfig.java
@@ -102,7 +102,8 @@ public class SecurityConfig {
 					).authenticated()
 
 					.requestMatchers(
-						mvc.matcher(GET, ESTIMATE_URI + "/{estimateId}")
+						mvc.matcher(GET, ESTIMATE_URI + "/{estimateId}"),
+						mvc.matcher(PUT, ESTIMATE_URI + "/{estimateId}/status")
 					).authenticated()
 
 					.anyRequest().permitAll()

--- a/src/main/java/com/carumuch/capstone/common/infrastructure/config/SecurityConfig.java
+++ b/src/main/java/com/carumuch/capstone/common/infrastructure/config/SecurityConfig.java
@@ -104,6 +104,7 @@ public class SecurityConfig {
 					.requestMatchers(
 						mvc.matcher(GET, ESTIMATE_URI + "/{estimateId}"),
 						mvc.matcher(GET, ESTIMATE_URI),
+						mvc.matcher(GET, ESTIMATE_URI + "/search"),
 						mvc.matcher(PUT, ESTIMATE_URI + "/{estimateId}/status")
 					).authenticated()
 

--- a/src/main/java/com/carumuch/capstone/damage/application/DamageReportService.java
+++ b/src/main/java/com/carumuch/capstone/damage/application/DamageReportService.java
@@ -35,7 +35,7 @@ public class DamageReportService {
 	public Long register(RegisterDamageReportRequest requestDto, Long userId) {
 		Vehicle vehicle = vehicleRepository.findByUserId(userId)
 			.orElseThrow(() -> new NotFoundException(Vehicle.class));
-		DamageReport damageReport = damageReportRepository.save(requestDto.toEntity(vehicle));
+		DamageReport damageReport = damageReportRepository.save(requestDto.toEntity(vehicle, userId));
 
 		eventPublisher.publishEvent(new DamageReportRegisteredEvent(
 			damageReport.getId(),

--- a/src/main/java/com/carumuch/capstone/damage/domain/report/DamageReport.java
+++ b/src/main/java/com/carumuch/capstone/damage/domain/report/DamageReport.java
@@ -56,13 +56,17 @@ public class DamageReport extends AggregateRoot<DamageReport> {
 	@JoinColumn(name = "vehicle_id")
 	private Vehicle vehicle;
 
-	public DamageReport(String description, RepairRegion preferredRepairRegion, boolean isPickupRequired, String imagePath, Vehicle vehicle) {
+	@Column(name = "userId", nullable = false)
+	private Long userId;
+
+	public DamageReport(String description, RepairRegion preferredRepairRegion, boolean isPickupRequired, String imagePath, Vehicle vehicle, Long userId) {
 		this.preferredRepairRegion = preferredRepairRegion;
 		this.description = description;
 		this.isPickupRequired = isPickupRequired;
 		this.imagePath = imagePath;
 		this.status = DamageReportStatus.REGISTERED;
 		this.vehicle = vehicle;
+		this.userId = userId;
 	}
 
 	public void update(String description, RepairRegion preferredRepairRegion, boolean isPickupRequired) {

--- a/src/main/java/com/carumuch/capstone/damage/domain/report/DamageReport.java
+++ b/src/main/java/com/carumuch/capstone/damage/domain/report/DamageReport.java
@@ -56,7 +56,7 @@ public class DamageReport extends AggregateRoot<DamageReport> {
 	@JoinColumn(name = "vehicle_id", nullable = false)
 	private Vehicle vehicle;
 
-	@Column(name = "userId", nullable = false)
+	@Column(name = "user_id", nullable = false)
 	private Long userId;
 
 	public DamageReport(String description, RepairRegion preferredRepairRegion, boolean isPickupRequired, String imagePath, Vehicle vehicle, Long userId) {

--- a/src/main/java/com/carumuch/capstone/damage/domain/report/DamageReport.java
+++ b/src/main/java/com/carumuch/capstone/damage/domain/report/DamageReport.java
@@ -52,8 +52,8 @@ public class DamageReport extends AggregateRoot<DamageReport> {
 	@Column(name = "status", length = 20, nullable = false)
 	private DamageReportStatus status;
 
-	@ManyToOne(fetch = LAZY)
-	@JoinColumn(name = "vehicle_id")
+	@ManyToOne(fetch = LAZY, optional = false)
+	@JoinColumn(name = "vehicle_id", nullable = false)
 	private Vehicle vehicle;
 
 	@Column(name = "userId", nullable = false)

--- a/src/main/java/com/carumuch/capstone/damage/presentation/dto/request/report/RegisterDamageReportRequest.java
+++ b/src/main/java/com/carumuch/capstone/damage/presentation/dto/request/report/RegisterDamageReportRequest.java
@@ -13,13 +13,14 @@ public record RegisterDamageReportRequest(
 	@NotNull Boolean isPickupRequired,
 	@NotNull String imagePath
 ) {
-	public DamageReport toEntity(Vehicle vehicle) {
+	public DamageReport toEntity(Vehicle vehicle, Long userId) {
 		return new DamageReport(
 			description,
 			new RepairRegion(preferredRepairSido, preferredRepairSigungu),
 			isPickupRequired,
 			imagePath,
-			vehicle
+			vehicle,
+			userId
 		);
 	}
 }

--- a/src/main/java/com/carumuch/capstone/estimate/application/EstimateService.java
+++ b/src/main/java/com/carumuch/capstone/estimate/application/EstimateService.java
@@ -1,5 +1,6 @@
 package com.carumuch.capstone.estimate.application;
 
+import com.carumuch.capstone.common.exception.ForbiddenException;
 import com.carumuch.capstone.common.exception.NotFoundException;
 import com.carumuch.capstone.common.presentation.dto.PagingRequest;
 import com.carumuch.capstone.common.presentation.dto.PagingResponse;
@@ -9,6 +10,7 @@ import com.carumuch.capstone.estimate.domain.EstimateRepository;
 import com.carumuch.capstone.estimate.domain.EstimateStatus;
 import com.carumuch.capstone.estimate.presentation.dto.request.SearchEstimateRequest;
 import com.carumuch.capstone.estimate.presentation.dto.response.EstimateDetailResponse;
+import com.carumuch.capstone.identity.domain.user.User;
 
 import lombok.RequiredArgsConstructor;
 
@@ -38,9 +40,12 @@ public class EstimateService {
 	}
 
 	@Transactional
-	public void changeStatus(Long estimateId, String status) {
+	public void changeStatus(Long estimateId, String status, Long userId) {
 		Estimate estimate = estimateRepository.findById(estimateId)
 			.orElseThrow(() -> new NotFoundException(Estimate.class));
+		if (!estimate.canAccess(userId)) {
+			throw new ForbiddenException();
+		}
 		estimate.updateStatus(EstimateStatus.from(status));
 	}
 

--- a/src/main/java/com/carumuch/capstone/estimate/application/EstimateService.java
+++ b/src/main/java/com/carumuch/capstone/estimate/application/EstimateService.java
@@ -23,6 +23,12 @@ public class EstimateService {
 			.orElseThrow(() -> new NotFoundException(Estimate.class));
 	}
 
+	public EstimateDetailResponse findEstimateDetailByDamageReportId(Long damageReportId) {
+		return estimateRepository.findDetailByDamageReportId(damageReportId)
+			.map(EstimateDetailResponse::new)
+			.orElseThrow(() -> new NotFoundException(Estimate.class));
+	}
+
 	@Transactional
 	public void changeStatus(Long estimateId, String status) {
 		Estimate estimate = estimateRepository.findById(estimateId)

--- a/src/main/java/com/carumuch/capstone/estimate/application/EstimateService.java
+++ b/src/main/java/com/carumuch/capstone/estimate/application/EstimateService.java
@@ -3,6 +3,7 @@ package com.carumuch.capstone.estimate.application;
 import com.carumuch.capstone.common.exception.NotFoundException;
 import com.carumuch.capstone.estimate.domain.Estimate;
 import com.carumuch.capstone.estimate.domain.EstimateRepository;
+import com.carumuch.capstone.estimate.domain.EstimateStatus;
 import com.carumuch.capstone.estimate.presentation.dto.response.EstimateDetailResponse;
 
 import lombok.RequiredArgsConstructor;
@@ -20,5 +21,12 @@ public class EstimateService {
 		return estimateRepository.findDetailById(estimateId)
 			.map(EstimateDetailResponse::new)
 			.orElseThrow(() -> new NotFoundException(Estimate.class));
+	}
+
+	@Transactional
+	public void changeStatus(Long estimateId, String status) {
+		Estimate estimate = estimateRepository.findById(estimateId)
+			.orElseThrow(() -> new NotFoundException(Estimate.class));
+		estimate.updateStatus(EstimateStatus.from(status));
 	}
 }

--- a/src/main/java/com/carumuch/capstone/estimate/application/EstimateService.java
+++ b/src/main/java/com/carumuch/capstone/estimate/application/EstimateService.java
@@ -1,12 +1,20 @@
 package com.carumuch.capstone.estimate.application;
 
 import com.carumuch.capstone.common.exception.NotFoundException;
+import com.carumuch.capstone.common.presentation.dto.PagingRequest;
+import com.carumuch.capstone.common.presentation.dto.PagingResponse;
+import com.carumuch.capstone.estimate.application.dto.EstimateSearchCondition;
 import com.carumuch.capstone.estimate.domain.Estimate;
 import com.carumuch.capstone.estimate.domain.EstimateRepository;
 import com.carumuch.capstone.estimate.domain.EstimateStatus;
+import com.carumuch.capstone.estimate.presentation.dto.request.SearchEstimateRequest;
 import com.carumuch.capstone.estimate.presentation.dto.response.EstimateDetailResponse;
 
 import lombok.RequiredArgsConstructor;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -34,5 +42,13 @@ public class EstimateService {
 		Estimate estimate = estimateRepository.findById(estimateId)
 			.orElseThrow(() -> new NotFoundException(Estimate.class));
 		estimate.updateStatus(EstimateStatus.from(status));
+	}
+
+	public PagingResponse<EstimateDetailResponse> searchEstimates(SearchEstimateRequest searchEstimateRequest, PagingRequest pagingRequest) {
+		Page<Estimate> estimates = estimateRepository.searchEstimates(
+			EstimateSearchCondition.from(searchEstimateRequest),
+			PageRequest.of(pagingRequest.page(), pagingRequest.size(), Sort.by(pagingRequest.sort()))
+		);
+		return PagingResponse.from(estimates.map(EstimateDetailResponse::new));
 	}
 }

--- a/src/main/java/com/carumuch/capstone/estimate/application/EstimateService.java
+++ b/src/main/java/com/carumuch/capstone/estimate/application/EstimateService.java
@@ -10,7 +10,6 @@ import com.carumuch.capstone.estimate.domain.EstimateRepository;
 import com.carumuch.capstone.estimate.domain.EstimateStatus;
 import com.carumuch.capstone.estimate.presentation.dto.request.SearchEstimateRequest;
 import com.carumuch.capstone.estimate.presentation.dto.response.EstimateDetailResponse;
-import com.carumuch.capstone.identity.domain.user.User;
 
 import lombok.RequiredArgsConstructor;
 
@@ -46,7 +45,7 @@ public class EstimateService {
 		if (!estimate.canAccess(userId)) {
 			throw new ForbiddenException();
 		}
-		estimate.updateStatus(EstimateStatus.from(status));
+		estimate.changeStatus(EstimateStatus.from(status));
 	}
 
 	public PagingResponse<EstimateDetailResponse> searchEstimates(SearchEstimateRequest searchEstimateRequest, PagingRequest pagingRequest) {

--- a/src/main/java/com/carumuch/capstone/estimate/application/EstimateService.java
+++ b/src/main/java/com/carumuch/capstone/estimate/application/EstimateService.java
@@ -1,18 +1,24 @@
 package com.carumuch.capstone.estimate.application;
 
+import com.carumuch.capstone.common.exception.NotFoundException;
+import com.carumuch.capstone.estimate.domain.Estimate;
 import com.carumuch.capstone.estimate.domain.EstimateRepository;
+import com.carumuch.capstone.estimate.presentation.dto.response.EstimateDetailResponse;
 
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 
 @Service
-@Slf4j
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class EstimateService {
     private final EstimateRepository estimateRepository;
 
+	public EstimateDetailResponse findEstimateDetail(Long estimateId) {
+		return estimateRepository.findDetailById(estimateId)
+			.map(EstimateDetailResponse::new)
+			.orElseThrow(() -> new NotFoundException(Estimate.class));
+	}
 }

--- a/src/main/java/com/carumuch/capstone/estimate/application/dto/EstimateSearchCondition.java
+++ b/src/main/java/com/carumuch/capstone/estimate/application/dto/EstimateSearchCondition.java
@@ -1,0 +1,27 @@
+package com.carumuch.capstone.estimate.application.dto;
+
+import com.carumuch.capstone.estimate.presentation.dto.request.SearchEstimateRequest;
+
+public record EstimateSearchCondition(
+	Integer minRepairCost,
+	Integer maxRepairCost,
+	String sido,
+	String sigungu,
+	Boolean isPickupRequired,
+	String brand,
+	Integer modelYear,
+	String modelName
+) {
+	public EstimateSearchCondition from(SearchEstimateRequest request) {
+		return new EstimateSearchCondition(
+			request.minRepairCost(),
+			request.maxRepairCost(),
+			request.sido(),
+			request.sigungu(),
+			request.isPickupRequired(),
+			request.brand(),
+			request.modelYear(),
+			request.modelName()
+		);
+	}
+}

--- a/src/main/java/com/carumuch/capstone/estimate/application/dto/EstimateSearchCondition.java
+++ b/src/main/java/com/carumuch/capstone/estimate/application/dto/EstimateSearchCondition.java
@@ -12,7 +12,7 @@ public record EstimateSearchCondition(
 	Integer modelYear,
 	String modelName
 ) {
-	public EstimateSearchCondition from(SearchEstimateRequest request) {
+	public static EstimateSearchCondition from(SearchEstimateRequest request) {
 		return new EstimateSearchCondition(
 			request.minRepairCost(),
 			request.maxRepairCost(),

--- a/src/main/java/com/carumuch/capstone/estimate/domain/Estimate.java
+++ b/src/main/java/com/carumuch/capstone/estimate/domain/Estimate.java
@@ -27,7 +27,7 @@ import org.springframework.http.HttpStatus;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Estimate extends AggregateRoot<Estimate> implements AccessPolicy {
 
-	@Column(name = "ai_estimated_repair_cost")
+	@Column(name = "ai_estimated_repair_cost", nullable = false)
 	private Integer repairCost;
 
 	@ElementCollection(fetch = FetchType.LAZY)
@@ -36,24 +36,24 @@ public class Estimate extends AggregateRoot<Estimate> implements AccessPolicy {
 	private Set<String> repairParts = new HashSet<>();
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "status")
+    @Column(name = "status", length = 20, nullable = false)
     private EstimateStatus estimateStatus;
 
     @Column(name = "applicant_count")
     private int applicantCount;
 
-	@Column(name = "image_path", length = 500)
+	@Column(name = "image_path", length = 500, nullable = false)
 	private String imagePath;
 
-	@OneToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "damage_report_id", unique = true)
+	@OneToOne(fetch = FetchType.LAZY, optional = false)
+	@JoinColumn(name = "damage_report_id", unique = true, nullable = false)
 	private DamageReport damageReport;
+
+	@Column(name = "user_id", nullable = false)
+	private Long userId;
 
     @OneToMany(mappedBy = "estimate", cascade = ALL)
     private List<Bid> bids = new ArrayList<>();
-
-	@Column(name = "user_id")
-	private Long userId;
 
     public Estimate(
 		Integer repairCost,

--- a/src/main/java/com/carumuch/capstone/estimate/domain/Estimate.java
+++ b/src/main/java/com/carumuch/capstone/estimate/domain/Estimate.java
@@ -2,6 +2,7 @@ package com.carumuch.capstone.estimate.domain;
 
 import com.carumuch.capstone.bidding.domain.Bid;
 import com.carumuch.capstone.common.domain.AggregateRoot;
+import com.carumuch.capstone.common.exception.CustomException;
 import com.carumuch.capstone.damage.domain.report.DamageReport;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -14,6 +15,8 @@ import java.util.List;
 import java.util.Set;
 
 import static jakarta.persistence.CascadeType.ALL;
+
+import org.springframework.http.HttpStatus;
 
 @Entity
 @Table(name = "estimate")
@@ -60,7 +63,10 @@ public class Estimate extends AggregateRoot<Estimate> {
 		this.damageReport = damageReport;
     }
 
-    public void update(EstimateStatus estimateStatus) {
+    public void updateStatus(EstimateStatus estimateStatus) {
+		if (this.estimateStatus == EstimateStatus.CLOSED) {
+			throw new CustomException(HttpStatus.BAD_REQUEST, "이미 매칭된 견적서 입니다.");
+		}
         this.estimateStatus = estimateStatus;
     }
 

--- a/src/main/java/com/carumuch/capstone/estimate/domain/Estimate.java
+++ b/src/main/java/com/carumuch/capstone/estimate/domain/Estimate.java
@@ -5,7 +5,6 @@ import com.carumuch.capstone.common.domain.AccessPolicy;
 import com.carumuch.capstone.common.domain.AggregateRoot;
 import com.carumuch.capstone.common.exception.CustomException;
 import com.carumuch.capstone.damage.domain.report.DamageReport;
-import com.carumuch.capstone.identity.domain.user.User;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -78,8 +77,8 @@ public class Estimate extends AggregateRoot<Estimate> implements AccessPolicy {
     }
 
 	@Override
-	public boolean canAccess(User user) {
-		return user.getId().equals(this.userId);
+	public boolean canAccess(Long userId) {
+		return userId.equals(this.userId);
 	}
 
 	// TODO: 원자적 연산이 아니라 동시성 문제가 우려됨, 수정 필요

--- a/src/main/java/com/carumuch/capstone/estimate/domain/Estimate.java
+++ b/src/main/java/com/carumuch/capstone/estimate/domain/Estimate.java
@@ -78,6 +78,11 @@ public class Estimate extends AggregateRoot<Estimate> implements AccessPolicy {
         this.estimateStatus = estimateStatus;
     }
 
+	public void closeBidding() {
+		validateStatus();
+		this.estimateStatus = EstimateStatus.CLOSED;
+	}
+
 	private void validateStatus() {
 		if (this.estimateStatus == EstimateStatus.CLOSED) {
 			throw new CustomException(HttpStatus.BAD_REQUEST, "이미 매칭된 견적서 입니다.");

--- a/src/main/java/com/carumuch/capstone/estimate/domain/Estimate.java
+++ b/src/main/java/com/carumuch/capstone/estimate/domain/Estimate.java
@@ -14,6 +14,7 @@ import lombok.NoArgsConstructor;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 import static jakarta.persistence.CascadeType.ALL;
@@ -78,7 +79,7 @@ public class Estimate extends AggregateRoot<Estimate> implements AccessPolicy {
 
 	@Override
 	public boolean canAccess(Long userId) {
-		return userId.equals(this.userId);
+		return Objects.equals(this.userId, userId);
 	}
 
 	// TODO: 원자적 연산이 아니라 동시성 문제가 우려됨, 수정 필요

--- a/src/main/java/com/carumuch/capstone/estimate/domain/Estimate.java
+++ b/src/main/java/com/carumuch/capstone/estimate/domain/Estimate.java
@@ -1,9 +1,12 @@
 package com.carumuch.capstone.estimate.domain;
 
 import com.carumuch.capstone.bidding.domain.Bid;
+import com.carumuch.capstone.common.domain.AccessPolicy;
 import com.carumuch.capstone.common.domain.AggregateRoot;
 import com.carumuch.capstone.common.exception.CustomException;
 import com.carumuch.capstone.damage.domain.report.DamageReport;
+import com.carumuch.capstone.identity.domain.user.User;
+
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -22,7 +25,7 @@ import org.springframework.http.HttpStatus;
 @Table(name = "estimate")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Estimate extends AggregateRoot<Estimate> {
+public class Estimate extends AggregateRoot<Estimate> implements AccessPolicy {
 
 	@Column(name = "ai_estimated_repair_cost")
 	private Integer repairCost;
@@ -49,6 +52,9 @@ public class Estimate extends AggregateRoot<Estimate> {
     @OneToMany(mappedBy = "estimate", cascade = ALL)
     private List<Bid> bids = new ArrayList<>();
 
+	@Column(name = "user_id")
+	private Long userId;
+
     public Estimate(
 		Integer repairCost,
 		Set<String> repairParts,
@@ -61,6 +67,7 @@ public class Estimate extends AggregateRoot<Estimate> {
         this.estimateStatus = estimateStatus;
 		this.imagePath = imagePath;
 		this.damageReport = damageReport;
+		this.userId = damageReport.getUserId();
     }
 
     public void updateStatus(EstimateStatus estimateStatus) {
@@ -70,7 +77,12 @@ public class Estimate extends AggregateRoot<Estimate> {
         this.estimateStatus = estimateStatus;
     }
 
-    // TODO: 원자적 연산이 아니라 동시성 문제가 우려됨, 수정 필요
+	@Override
+	public boolean canAccess(User user) {
+		return user.getId().equals(this.userId);
+	}
+
+	// TODO: 원자적 연산이 아니라 동시성 문제가 우려됨, 수정 필요
     public void increaseApplicant() {
         this.applicantCount += 1;
     }

--- a/src/main/java/com/carumuch/capstone/estimate/domain/Estimate.java
+++ b/src/main/java/com/carumuch/capstone/estimate/domain/Estimate.java
@@ -36,6 +36,9 @@ public class Estimate extends AggregateRoot<Estimate> {
     @Column(name = "applicant_count")
     private int applicantCount;
 
+	@Column(name = "image_path", length = 500)
+	private String imagePath;
+
 	@OneToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "damage_report_id", unique = true)
 	private DamageReport damageReport;
@@ -43,10 +46,17 @@ public class Estimate extends AggregateRoot<Estimate> {
     @OneToMany(mappedBy = "estimate", cascade = ALL)
     private List<Bid> bids = new ArrayList<>();
 
-    public Estimate(Integer repairCost, Set<String> repairParts, EstimateStatus estimateStatus, DamageReport damageReport) {
+    public Estimate(
+		Integer repairCost,
+		Set<String> repairParts,
+		EstimateStatus estimateStatus,
+		String imagePath,
+		DamageReport damageReport
+	) {
         this.repairCost = repairCost;
 		this.repairParts = repairParts;
         this.estimateStatus = estimateStatus;
+		this.imagePath = imagePath;
 		this.damageReport = damageReport;
     }
 

--- a/src/main/java/com/carumuch/capstone/estimate/domain/Estimate.java
+++ b/src/main/java/com/carumuch/capstone/estimate/domain/Estimate.java
@@ -70,12 +70,19 @@ public class Estimate extends AggregateRoot<Estimate> implements AccessPolicy {
 		this.userId = damageReport.getUserId();
     }
 
-    public void updateStatus(EstimateStatus estimateStatus) {
+    public void changeStatus(EstimateStatus estimateStatus) {
+		if (estimateStatus == EstimateStatus.CLOSED) {
+			throw new CustomException(HttpStatus.BAD_REQUEST, "CLOSED 상태로는 변경할 수 없습니다.");
+		}
+		validateStatus();
+        this.estimateStatus = estimateStatus;
+    }
+
+	private void validateStatus() {
 		if (this.estimateStatus == EstimateStatus.CLOSED) {
 			throw new CustomException(HttpStatus.BAD_REQUEST, "이미 매칭된 견적서 입니다.");
 		}
-        this.estimateStatus = estimateStatus;
-    }
+	}
 
 	@Override
 	public boolean canAccess(Long userId) {

--- a/src/main/java/com/carumuch/capstone/estimate/domain/EstimateRepository.java
+++ b/src/main/java/com/carumuch/capstone/estimate/domain/EstimateRepository.java
@@ -9,4 +9,6 @@ public interface EstimateRepository {
 	Optional<Estimate> findById(Long id);
 
 	Optional<Estimate> findDetailById(Long id);
+
+	Optional<Estimate> findDetailByDamageReportId(Long damageReportId);
 }

--- a/src/main/java/com/carumuch/capstone/estimate/domain/EstimateRepository.java
+++ b/src/main/java/com/carumuch/capstone/estimate/domain/EstimateRepository.java
@@ -2,6 +2,11 @@ package com.carumuch.capstone.estimate.domain;
 
 import java.util.Optional;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import com.carumuch.capstone.estimate.application.dto.EstimateSearchCondition;
+
 public interface EstimateRepository {
 
 	Estimate save(Estimate estimate);
@@ -11,4 +16,6 @@ public interface EstimateRepository {
 	Optional<Estimate> findDetailById(Long id);
 
 	Optional<Estimate> findDetailByDamageReportId(Long damageReportId);
+
+	Page<Estimate> searchEstimates(EstimateSearchCondition condition, Pageable pageable);
 }

--- a/src/main/java/com/carumuch/capstone/estimate/domain/EstimateRepository.java
+++ b/src/main/java/com/carumuch/capstone/estimate/domain/EstimateRepository.java
@@ -7,4 +7,6 @@ public interface EstimateRepository {
 	Estimate save(Estimate estimate);
 
 	Optional<Estimate> findById(Long id);
+
+	Optional<Estimate> findDetailById(Long id);
 }

--- a/src/main/java/com/carumuch/capstone/estimate/domain/EstimateStatus.java
+++ b/src/main/java/com/carumuch/capstone/estimate/domain/EstimateStatus.java
@@ -1,7 +1,16 @@
 package com.carumuch.capstone.estimate.domain;
 
+import java.util.Arrays;
+import org.springframework.http.HttpStatus;
+import com.carumuch.capstone.common.exception.CustomException;
+
 public enum EstimateStatus {
-	OPEN,
-	CLOSED,
-	PRIVATE
+	OPEN, CLOSED, PRIVATE;
+
+	public static EstimateStatus from(String value) {
+		return Arrays.stream(EstimateStatus.values())
+			.filter(state -> state.name().equalsIgnoreCase(value))
+			.findFirst()
+			.orElseThrow(() -> new CustomException(HttpStatus.BAD_REQUEST, "올바른 견적서 상태가 아닙니다."));
+	}
 }

--- a/src/main/java/com/carumuch/capstone/estimate/infrastructure/mq/EstimateResultListener.java
+++ b/src/main/java/com/carumuch/capstone/estimate/infrastructure/mq/EstimateResultListener.java
@@ -18,6 +18,8 @@ import lombok.RequiredArgsConstructor;
 @Component
 @RequiredArgsConstructor
 public class EstimateResultListener {
+	private static final String INVALID_MESSAGE = RabbitMqConfig.ESTIMATE_RESULT_Q + ": 유효하지 않은 메시지입니다.";
+
 	private final EstimateRepository estimateRepository;
 	private final DamageReportRepository damageReportRepository;
 
@@ -25,19 +27,19 @@ public class EstimateResultListener {
 	@RabbitListener(queues = RabbitMqConfig.ESTIMATE_RESULT_Q)
 	public void onResult(EstimateResultMessage message) {
 		if (message == null || message.damageReportId() == null) {
-			throw new AmqpRejectAndDontRequeueException(
-				RabbitMqConfig.ESTIMATE_RESULT_Q + ": 유효하지 않는 메세지입니다."
-			);
+			throw new AmqpRejectAndDontRequeueException(INVALID_MESSAGE);
 		}
 
-		DamageReport damageReportRef = damageReportRepository.getReferenceById(message.damageReportId());
+		DamageReport damageReport = damageReportRepository.findById(message.damageReportId())
+			.orElseThrow(() -> new AmqpRejectAndDontRequeueException(INVALID_MESSAGE));
+
 		estimateRepository.save(
 			new Estimate(
 				message.repairCost(),
 				message.repairParts(),
 				EstimateStatus.OPEN,
 				message.imagePath(),
-				damageReportRef
+				damageReport
 			)
 		);
 	}

--- a/src/main/java/com/carumuch/capstone/estimate/infrastructure/mq/EstimateResultListener.java
+++ b/src/main/java/com/carumuch/capstone/estimate/infrastructure/mq/EstimateResultListener.java
@@ -32,7 +32,13 @@ public class EstimateResultListener {
 
 		DamageReport damageReportRef = damageReportRepository.getReferenceById(message.damageReportId());
 		estimateRepository.save(
-			new Estimate(message.repairCost(), message.repairParts(), EstimateStatus.OPEN, damageReportRef)
+			new Estimate(
+				message.repairCost(),
+				message.repairParts(),
+				EstimateStatus.OPEN,
+				message.imagePath(),
+				damageReportRef
+			)
 		);
 	}
 }

--- a/src/main/java/com/carumuch/capstone/estimate/infrastructure/persistence/DynamicBooleanBuilder.java
+++ b/src/main/java/com/carumuch/capstone/estimate/infrastructure/persistence/DynamicBooleanBuilder.java
@@ -1,0 +1,39 @@
+package com.carumuch.capstone.estimate.infrastructure.persistence;
+
+import java.util.function.Supplier;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.dsl.BooleanExpression;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class DynamicBooleanBuilder {
+
+	private final BooleanBuilder booleanBuilder = new BooleanBuilder();
+
+	public static DynamicBooleanBuilder builder() {
+		return new DynamicBooleanBuilder();
+	}
+
+	public DynamicBooleanBuilder and(Supplier<BooleanExpression> expressionSupplier) {
+		try {
+			booleanBuilder.and(expressionSupplier.get());
+		} catch (IllegalArgumentException | NullPointerException ignored) {
+		}
+		return this;
+	}
+
+	public DynamicBooleanBuilder or(Supplier<BooleanExpression> expressionSupplier) {
+		try {
+			booleanBuilder.or(expressionSupplier.get());
+		} catch (IllegalArgumentException | NullPointerException ignored) {
+		}
+		return this;
+	}
+
+	public BooleanBuilder build() {
+		return booleanBuilder;
+	}
+}

--- a/src/main/java/com/carumuch/capstone/estimate/infrastructure/persistence/EstimateQueryRepository.java
+++ b/src/main/java/com/carumuch/capstone/estimate/infrastructure/persistence/EstimateQueryRepository.java
@@ -1,0 +1,11 @@
+package com.carumuch.capstone.estimate.infrastructure.persistence;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import com.carumuch.capstone.estimate.application.dto.EstimateSearchCondition;
+import com.carumuch.capstone.estimate.domain.Estimate;
+
+public interface EstimateQueryRepository {
+	Page<Estimate> searchEstimates(EstimateSearchCondition condition, Pageable pageable);
+}

--- a/src/main/java/com/carumuch/capstone/estimate/infrastructure/persistence/EstimateQueryRepositoryImpl.java
+++ b/src/main/java/com/carumuch/capstone/estimate/infrastructure/persistence/EstimateQueryRepositoryImpl.java
@@ -1,0 +1,90 @@
+package com.carumuch.capstone.estimate.infrastructure.persistence;
+
+import static com.carumuch.capstone.estimate.domain.QEstimate.*;
+
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Repository;
+
+import com.carumuch.capstone.damage.domain.report.QDamageReport;
+import com.carumuch.capstone.damage.domain.vehicle.QVehicle;
+import com.carumuch.capstone.estimate.application.dto.EstimateSearchCondition;
+import com.carumuch.capstone.estimate.domain.Estimate;
+import com.carumuch.capstone.estimate.domain.EstimateStatus;
+import com.carumuch.capstone.estimate.domain.QEstimate;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class EstimateQueryRepositoryImpl implements EstimateQueryRepository {
+
+	private static final String POPULAR_SORT = "POPULAR";
+	private static final String DEFAULT_SORT = "DEFAULT";
+	private static final OrderSpecifier<?>[] ORDER_POPULAR = {QEstimate.estimate.applicantCount.desc()};
+	private static final OrderSpecifier<?>[] ORDER_DEFAULT = {QEstimate.estimate.createDate.desc()};
+
+	private final JPAQueryFactory jpaQueryFactory;
+
+	@Override
+	public Page<Estimate> searchEstimates(EstimateSearchCondition condition, Pageable pageable) {
+
+		QDamageReport dr = QDamageReport.damageReport;
+		QVehicle v = QVehicle.vehicle;
+		BooleanBuilder predicate = buildPredicate(condition, dr, v);
+
+		List<Estimate> content = jpaQueryFactory
+			.select(estimate)
+			.from(estimate)
+			.join(estimate.damageReport, dr).fetchJoin()
+			.join(dr.vehicle, v).fetchJoin()
+			.where(predicate)
+			.orderBy(getOrderSpecifier(pageable))
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize())
+			.fetch();
+
+		JPAQuery<Long> countQuery = jpaQueryFactory
+			.select(estimate.count())
+			.from(estimate)
+			.join(estimate.damageReport, dr)
+			.join(dr.vehicle, v)
+			.where(predicate);
+
+		return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+	}
+
+	private BooleanBuilder buildPredicate(EstimateSearchCondition condition, QDamageReport dr, QVehicle v) {
+		return DynamicBooleanBuilder.builder()
+			.and(() -> estimate.estimateStatus.eq(EstimateStatus.OPEN))
+			.and(() -> estimate.repairCost.loe(condition.maxRepairCost()))
+			.and(() -> estimate.repairCost.goe(condition.minRepairCost()))
+			.and(() -> dr.isPickupRequired.eq(condition.isPickupRequired()))
+			.and(() -> dr.preferredRepairRegion.sido.eq(condition.sido()))
+			.and(() -> dr.preferredRepairRegion.sigungu.eq(condition.sigungu()))
+			.and(() -> v.modelName.eq(condition.modelName()))
+			.and(() -> v.modelYear.eq(condition.modelYear()))
+			.and(() -> v.brand.eq(condition.brand()))
+			.build();
+	}
+
+	private OrderSpecifier<?>[] getOrderSpecifier(Pageable pageable) {
+		String sort = pageable.getSort().stream()
+			.findFirst()
+			.map(Sort.Order::getProperty)
+			.orElse(DEFAULT_SORT);
+
+		return switch (sort) {
+			case POPULAR_SORT -> ORDER_POPULAR;
+			default -> ORDER_DEFAULT;
+		};
+	}
+}

--- a/src/main/java/com/carumuch/capstone/estimate/infrastructure/persistence/EstimateRepositoryImpl.java
+++ b/src/main/java/com/carumuch/capstone/estimate/infrastructure/persistence/EstimateRepositoryImpl.java
@@ -29,4 +29,9 @@ public class EstimateRepositoryImpl implements EstimateRepository {
 	public Optional<Estimate> findDetailById(Long id) {
 		return jpaEstimateRepository.findDetailById(id);
 	}
+
+	@Override
+	public Optional<Estimate> findDetailByDamageReportId(Long damageReportId) {
+		return jpaEstimateRepository.findDetailByDamageReportId(damageReportId);
+	}
 }

--- a/src/main/java/com/carumuch/capstone/estimate/infrastructure/persistence/EstimateRepositoryImpl.java
+++ b/src/main/java/com/carumuch/capstone/estimate/infrastructure/persistence/EstimateRepositoryImpl.java
@@ -24,4 +24,9 @@ public class EstimateRepositoryImpl implements EstimateRepository {
 	public Optional<Estimate> findById(Long id) {
 		return jpaEstimateRepository.findById(id);
 	}
+
+	@Override
+	public Optional<Estimate> findDetailById(Long id) {
+		return jpaEstimateRepository.findDetailById(id);
+	}
 }

--- a/src/main/java/com/carumuch/capstone/estimate/infrastructure/persistence/EstimateRepositoryImpl.java
+++ b/src/main/java/com/carumuch/capstone/estimate/infrastructure/persistence/EstimateRepositoryImpl.java
@@ -2,8 +2,11 @@ package com.carumuch.capstone.estimate.infrastructure.persistence;
 
 import java.util.Optional;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
+import com.carumuch.capstone.estimate.application.dto.EstimateSearchCondition;
 import com.carumuch.capstone.estimate.domain.Estimate;
 import com.carumuch.capstone.estimate.domain.EstimateRepository;
 
@@ -14,6 +17,7 @@ import lombok.RequiredArgsConstructor;
 public class EstimateRepositoryImpl implements EstimateRepository {
 
 	private final JpaEstimateRepository jpaEstimateRepository;
+	private final EstimateQueryRepository estimateQueryRepository;
 
 	@Override
 	public Estimate save(Estimate estimate) {
@@ -33,5 +37,10 @@ public class EstimateRepositoryImpl implements EstimateRepository {
 	@Override
 	public Optional<Estimate> findDetailByDamageReportId(Long damageReportId) {
 		return jpaEstimateRepository.findDetailByDamageReportId(damageReportId);
+	}
+
+	@Override
+	public Page<Estimate> searchEstimates(EstimateSearchCondition condition, Pageable pageable) {
+		return estimateQueryRepository.searchEstimates(condition, pageable);
 	}
 }

--- a/src/main/java/com/carumuch/capstone/estimate/infrastructure/persistence/JpaEstimateRepository.java
+++ b/src/main/java/com/carumuch/capstone/estimate/infrastructure/persistence/JpaEstimateRepository.java
@@ -1,8 +1,20 @@
 package com.carumuch.capstone.estimate.infrastructure.persistence;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.carumuch.capstone.estimate.domain.Estimate;
 
 public interface JpaEstimateRepository extends JpaRepository<Estimate, Long> {
+	@Query(
+		"SELECT DISTINCT e FROM Estimate e "
+			+ "JOIN FETCH e.damageReport dr "
+			+ "JOIN FETCH dr.vehicle "
+			+ "LEFT JOIN FETCH e.repairParts "
+			+ "WHERE e.id = :estimateId"
+	)
+	Optional<Estimate> findDetailById(@Param("estimateId") Long estimateId);
 }

--- a/src/main/java/com/carumuch/capstone/estimate/infrastructure/persistence/JpaEstimateRepository.java
+++ b/src/main/java/com/carumuch/capstone/estimate/infrastructure/persistence/JpaEstimateRepository.java
@@ -17,4 +17,13 @@ public interface JpaEstimateRepository extends JpaRepository<Estimate, Long> {
 			+ "WHERE e.id = :estimateId"
 	)
 	Optional<Estimate> findDetailById(@Param("estimateId") Long estimateId);
+
+	@Query(
+		"SELECT DISTINCT e FROM Estimate e "
+			+ "JOIN FETCH e.damageReport dr "
+			+ "JOIN FETCH dr.vehicle "
+			+ "LEFT JOIN FETCH e.repairParts "
+			+ "WHERE dr.id = :damageReportId"
+	)
+	Optional<Estimate> findDetailByDamageReportId(@Param("damageReportId") Long damageReportId);
 }

--- a/src/main/java/com/carumuch/capstone/estimate/presentation/EstimateController.java
+++ b/src/main/java/com/carumuch/capstone/estimate/presentation/EstimateController.java
@@ -1,8 +1,12 @@
 package com.carumuch.capstone.estimate.presentation;
 
+import com.carumuch.capstone.common.presentation.dto.ApiResponse;
 import com.carumuch.capstone.estimate.application.EstimateService;
+import com.carumuch.capstone.estimate.presentation.dto.response.EstimateDetailResponse;
 
 import lombok.RequiredArgsConstructor;
+
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 
@@ -12,4 +16,8 @@ import org.springframework.web.bind.annotation.*;
 public class EstimateController {
     private final EstimateService estimateService;
 
+	@GetMapping("/{estimateId}")
+	public ResponseEntity<ApiResponse<EstimateDetailResponse>> findEstimateDetail(@PathVariable Long estimateId) {
+		return ResponseEntity.ok().body(ApiResponse.of(estimateService.findEstimateDetail(estimateId)));
+	}
 }

--- a/src/main/java/com/carumuch/capstone/estimate/presentation/EstimateController.java
+++ b/src/main/java/com/carumuch/capstone/estimate/presentation/EstimateController.java
@@ -22,6 +22,11 @@ public class EstimateController {
 		return ResponseEntity.ok().body(ApiResponse.of(estimateService.findEstimateDetail(estimateId)));
 	}
 
+	@GetMapping
+	public ResponseEntity<ApiResponse<EstimateDetailResponse>> findByDamageReportId(@RequestParam Long damageReportId) {
+		return ResponseEntity.ok().body(ApiResponse.of(estimateService.findEstimateDetailByDamageReportId(damageReportId)));
+	}
+
 	@PutMapping( "/{estimateId}/status")
 	public ResponseEntity<ApiResponse<Void>> changeStatus(@PathVariable Long estimateId, @RequestBody UpdateEstimateStatusRequest updateEstimateStatusRequest) {
 		estimateService.changeStatus(estimateId, updateEstimateStatusRequest.status());

--- a/src/main/java/com/carumuch/capstone/estimate/presentation/EstimateController.java
+++ b/src/main/java/com/carumuch/capstone/estimate/presentation/EstimateController.java
@@ -2,6 +2,7 @@ package com.carumuch.capstone.estimate.presentation;
 
 import com.carumuch.capstone.common.presentation.dto.ApiResponse;
 import com.carumuch.capstone.estimate.application.EstimateService;
+import com.carumuch.capstone.estimate.presentation.dto.request.UpdateEstimateStatusRequest;
 import com.carumuch.capstone.estimate.presentation.dto.response.EstimateDetailResponse;
 
 import lombok.RequiredArgsConstructor;
@@ -22,8 +23,8 @@ public class EstimateController {
 	}
 
 	@PutMapping( "/{estimateId}/status")
-	public ResponseEntity<ApiResponse<Void>> changeStatus(@PathVariable Long estimateId, @RequestParam String status) {
-		estimateService.changeStatus(estimateId, status);
+	public ResponseEntity<ApiResponse<Void>> changeStatus(@PathVariable Long estimateId, @RequestBody UpdateEstimateStatusRequest updateEstimateStatusRequest) {
+		estimateService.changeStatus(estimateId, updateEstimateStatusRequest.status());
 		return ResponseEntity.ok().body(ApiResponse.of());
 	}
 }

--- a/src/main/java/com/carumuch/capstone/estimate/presentation/EstimateController.java
+++ b/src/main/java/com/carumuch/capstone/estimate/presentation/EstimateController.java
@@ -7,6 +7,7 @@ import com.carumuch.capstone.estimate.application.EstimateService;
 import com.carumuch.capstone.estimate.presentation.dto.request.SearchEstimateRequest;
 import com.carumuch.capstone.estimate.presentation.dto.request.UpdateEstimateStatusRequest;
 import com.carumuch.capstone.estimate.presentation.dto.response.EstimateDetailResponse;
+import com.carumuch.capstone.identity.domain.user.User;
 
 import lombok.RequiredArgsConstructor;
 
@@ -39,8 +40,8 @@ public class EstimateController {
 	}
 
 	@PutMapping( "/{estimateId}/status")
-	public ResponseEntity<ApiResponse<Void>> changeStatus(@PathVariable Long estimateId, @RequestBody UpdateEstimateStatusRequest updateEstimateStatusRequest) {
-		estimateService.changeStatus(estimateId, updateEstimateStatusRequest.status());
+	public ResponseEntity<ApiResponse<Void>> changeStatus(@PathVariable Long estimateId, @RequestBody UpdateEstimateStatusRequest updateEstimateStatusRequest, User user) {
+		estimateService.changeStatus(estimateId, updateEstimateStatusRequest.status(), user.getId());
 		return ResponseEntity.ok().body(ApiResponse.of());
 	}
 }

--- a/src/main/java/com/carumuch/capstone/estimate/presentation/EstimateController.java
+++ b/src/main/java/com/carumuch/capstone/estimate/presentation/EstimateController.java
@@ -1,7 +1,10 @@
 package com.carumuch.capstone.estimate.presentation;
 
 import com.carumuch.capstone.common.presentation.dto.ApiResponse;
+import com.carumuch.capstone.common.presentation.dto.PagingRequest;
+import com.carumuch.capstone.common.presentation.dto.PagingResponse;
 import com.carumuch.capstone.estimate.application.EstimateService;
+import com.carumuch.capstone.estimate.presentation.dto.request.SearchEstimateRequest;
 import com.carumuch.capstone.estimate.presentation.dto.request.UpdateEstimateStatusRequest;
 import com.carumuch.capstone.estimate.presentation.dto.response.EstimateDetailResponse;
 
@@ -25,6 +28,14 @@ public class EstimateController {
 	@GetMapping
 	public ResponseEntity<ApiResponse<EstimateDetailResponse>> findByDamageReportId(@RequestParam Long damageReportId) {
 		return ResponseEntity.ok().body(ApiResponse.of(estimateService.findEstimateDetailByDamageReportId(damageReportId)));
+	}
+
+	@GetMapping("/search")
+	public ResponseEntity<ApiResponse<PagingResponse<EstimateDetailResponse>>> search(
+		@ModelAttribute SearchEstimateRequest request,
+		@ModelAttribute PagingRequest pagingRequest
+	) {
+		return ResponseEntity.ok().body(ApiResponse.of(estimateService.searchEstimates(request, pagingRequest)));
 	}
 
 	@PutMapping( "/{estimateId}/status")

--- a/src/main/java/com/carumuch/capstone/estimate/presentation/EstimateController.java
+++ b/src/main/java/com/carumuch/capstone/estimate/presentation/EstimateController.java
@@ -20,4 +20,10 @@ public class EstimateController {
 	public ResponseEntity<ApiResponse<EstimateDetailResponse>> findEstimateDetail(@PathVariable Long estimateId) {
 		return ResponseEntity.ok().body(ApiResponse.of(estimateService.findEstimateDetail(estimateId)));
 	}
+
+	@PutMapping( "/{estimateId}/status")
+	public ResponseEntity<ApiResponse<Void>> changeStatus(@PathVariable Long estimateId, @RequestParam String status) {
+		estimateService.changeStatus(estimateId, status);
+		return ResponseEntity.ok().body(ApiResponse.of());
+	}
 }

--- a/src/main/java/com/carumuch/capstone/estimate/presentation/dto/request/SearchEstimateRequest.java
+++ b/src/main/java/com/carumuch/capstone/estimate/presentation/dto/request/SearchEstimateRequest.java
@@ -1,0 +1,13 @@
+package com.carumuch.capstone.estimate.presentation.dto.request;
+
+public record SearchEstimateRequest(
+	Integer minRepairCost,
+	Integer maxRepairCost,
+	String sido,
+	String sigungu,
+	Boolean isPickupRequired,
+	String brand,
+	Integer modelYear,
+	String modelName
+) {
+}

--- a/src/main/java/com/carumuch/capstone/estimate/presentation/dto/request/UpdateEstimateStatusRequest.java
+++ b/src/main/java/com/carumuch/capstone/estimate/presentation/dto/request/UpdateEstimateStatusRequest.java
@@ -1,0 +1,8 @@
+package com.carumuch.capstone.estimate.presentation.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record UpdateEstimateStatusRequest(
+	@NotNull String status
+) {
+}

--- a/src/main/java/com/carumuch/capstone/estimate/presentation/dto/response/EstimateDetailResponse.java
+++ b/src/main/java/com/carumuch/capstone/estimate/presentation/dto/response/EstimateDetailResponse.java
@@ -13,7 +13,7 @@ public record EstimateDetailResponse(
 	List<String> repairParts,
 	String estimateStatus,
 	String imagePath,
-	LocalDateTime createdDate,
+	LocalDateTime createdAt,
 	VehicleInfo vehicleInfo,
 	DamageReportInfo damageReportInfo
 ) {

--- a/src/main/java/com/carumuch/capstone/estimate/presentation/dto/response/EstimateDetailResponse.java
+++ b/src/main/java/com/carumuch/capstone/estimate/presentation/dto/response/EstimateDetailResponse.java
@@ -1,0 +1,70 @@
+package com.carumuch.capstone.estimate.presentation.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.carumuch.capstone.damage.domain.report.DamageReport;
+import com.carumuch.capstone.damage.domain.vehicle.Vehicle;
+import com.carumuch.capstone.estimate.domain.Estimate;
+
+public record EstimateDetailResponse(
+	Long estimateId,
+	Integer repairCost,
+	List<String> repairParts,
+	String estimateStatus,
+	String imagePath,
+	LocalDateTime createdDate,
+	VehicleInfo vehicleInfo,
+	DamageReportInfo damageReportInfo
+) {
+	public EstimateDetailResponse(Estimate estimate) {
+		this(
+			estimate.getId(),
+			estimate.getRepairCost(),
+			estimate.getRepairParts().stream()
+				.sorted()
+				.toList(),
+			estimate.getEstimateStatus().name(),
+			estimate.getImagePath(),
+			estimate.getCreateDate(),
+			new VehicleInfo(estimate.getDamageReport().getVehicle()),
+			new DamageReportInfo(estimate.getDamageReport())
+		);
+	}
+
+	private record VehicleInfo(
+		String licenseNumber,
+		String ownershipType,
+		String brand,
+		Integer modelYear,
+		String modelName,
+		String ownerName
+	) {
+		private VehicleInfo(Vehicle vehicle) {
+			this(
+				vehicle.getLicenseNumber().getValue(),
+				vehicle.getOwnershipType().name(),
+				vehicle.getBrand(),
+				vehicle.getModelYear(),
+				vehicle.getModelName(),
+				vehicle.getOwnerName()
+			);
+		}
+	}
+
+	private record DamageReportInfo(
+		String preferredRepairSido,
+		String preferredRepairSigungu,
+		String description,
+		Boolean isPickupRequired
+	) {
+		private DamageReportInfo(DamageReport damageReport) {
+			this(
+				damageReport.getPreferredRepairRegion().getSido(),
+				damageReport.getPreferredRepairRegion().getSigungu(),
+				damageReport.getDescription(),
+				damageReport.isPickupRequired()
+			);
+		}
+	}
+}

--- a/src/main/java/com/carumuch/capstone/estimate/presentation/dto/response/EstimateDetailResponse.java
+++ b/src/main/java/com/carumuch/capstone/estimate/presentation/dto/response/EstimateDetailResponse.java
@@ -32,7 +32,7 @@ public record EstimateDetailResponse(
 		);
 	}
 
-	private record VehicleInfo(
+	public record VehicleInfo(
 		String licenseNumber,
 		String ownershipType,
 		String brand,
@@ -52,7 +52,7 @@ public record EstimateDetailResponse(
 		}
 	}
 
-	private record DamageReportInfo(
+	public record DamageReportInfo(
 		String preferredRepairSido,
 		String preferredRepairSigungu,
 		String description,

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,7 +18,8 @@ spring:
     show-sql: true
     properties:
       hibernate:
-        format_sql:true
+        format_sql: true
+        default_batch_fetch_size: 100
   mail:
     #    host: smtp.naver.com
     host: smtp.${HOST_ADDRESS}
@@ -94,7 +95,8 @@ spring:
     show-sql: true
     properties:
       hibernate:
-        format_sql:true
+        format_sql: true
+        default_batch_fetch_size: 100
 
   mail:
     #    host: smtp.naver.com
@@ -170,7 +172,8 @@ spring:
     show-sql: true
     properties:
       hibernate:
-        format_sql:true
+        format_sql: true
+        default_batch_fetch_size: 100
 
   mail:
     #    host: smtp.naver.com

--- a/src/test/java/com/carumuch/capstone/damage/application/DamageReportServiceTest.java
+++ b/src/test/java/com/carumuch/capstone/damage/application/DamageReportServiceTest.java
@@ -49,7 +49,7 @@ class DamageReportServiceTest {
 	class Register {
 		@Test
 		void 사고_레포트_이벤트를_발행한다() {
-			Long vehicleId = 100L;
+			Long userId = 10L;
 			DamageReport damageReportFixture = DamageReportFixture.DAMAGE_REPORT_FIXTURE_1.create();
 			RegisterDamageReportRequest registerDamageReportRequest = new RegisterDamageReportRequest(
 				damageReportFixture.getDescription(),
@@ -58,14 +58,14 @@ class DamageReportServiceTest {
 				damageReportFixture.isPickupRequired(),
 				damageReportFixture.getImagePath()
 			);
-			Mockito.when(vehicleRepository.findByUserId(vehicleId)).thenReturn(Optional.of(damageReportFixture.getVehicle()));
-			DamageReport damageReport = registerDamageReportRequest.toEntity(damageReportFixture.getVehicle());
+			Mockito.when(vehicleRepository.findByUserId(userId)).thenReturn(Optional.of(damageReportFixture.getVehicle()));
+			DamageReport damageReport = registerDamageReportRequest.toEntity(damageReportFixture.getVehicle(), userId);
 			ReflectionTestUtils.setField(damageReport, "id", 1L);
 			Mockito.when(damageReportRepository.save(Mockito.any(DamageReport.class))).thenReturn(damageReport);
 			Mockito.doNothing().when(eventPublisher).publishEvent(Mockito.any(DamageReportRegisteredEvent.class));
 
 			//when
-			damageReportService.register(registerDamageReportRequest, vehicleId);
+			damageReportService.register(registerDamageReportRequest, userId);
 
 			//then
 			Mockito.verify(eventPublisher, Mockito.times(1))
@@ -75,7 +75,7 @@ class DamageReportServiceTest {
 		@Test
 		void 등록된_사용자의_차량을_조회한다() {
 		    //given
-			Long vehicleId = 100L;
+			Long userId = 10L;
 			DamageReport damageReportFixture = DamageReportFixture.DAMAGE_REPORT_FIXTURE_1.create();
 			RegisterDamageReportRequest registerDamageReportRequest = new RegisterDamageReportRequest(
 				damageReportFixture.getDescription(),
@@ -84,17 +84,17 @@ class DamageReportServiceTest {
 				damageReportFixture.isPickupRequired(),
 				damageReportFixture.getImagePath()
 			);
-			Mockito.when(vehicleRepository.findByUserId(vehicleId)).thenReturn(Optional.of(damageReportFixture.getVehicle()));
-			DamageReport damageReport = registerDamageReportRequest.toEntity(damageReportFixture.getVehicle());
+			Mockito.when(vehicleRepository.findByUserId(userId)).thenReturn(Optional.of(damageReportFixture.getVehicle()));
+			DamageReport damageReport = registerDamageReportRequest.toEntity(damageReportFixture.getVehicle(), userId);
 			ReflectionTestUtils.setField(damageReport, "id", 1L);
 			Mockito.when(damageReportRepository.save(Mockito.any(DamageReport.class))).thenReturn(damageReport);
 
 		    //when
-			damageReportService.register(registerDamageReportRequest, vehicleId);
+			damageReportService.register(registerDamageReportRequest, userId);
 
 		    //then
 		    Mockito.verify(vehicleRepository, Mockito.times(1))
-				.findByUserId(vehicleId);
+				.findByUserId(userId);
 		}
 
 		@Test
@@ -119,7 +119,7 @@ class DamageReportServiceTest {
 		@Test
 		void 사고_레포트를_등록한다() {
 		    //given
-			Long vehicleId = 1L;
+			Long userId = 10L;
 			DamageReport damageReportFixture = DamageReportFixture.DAMAGE_REPORT_FIXTURE_1.create();
 			RegisterDamageReportRequest registerDamageReportRequest = new RegisterDamageReportRequest(
 				damageReportFixture.getDescription(),
@@ -128,14 +128,14 @@ class DamageReportServiceTest {
 				damageReportFixture.isPickupRequired(),
 				damageReportFixture.getImagePath()
 			);
-			Mockito.when(vehicleRepository.findByUserId(vehicleId)).thenReturn(Optional.of(damageReportFixture.getVehicle()));
+			Mockito.when(vehicleRepository.findByUserId(userId)).thenReturn(Optional.of(damageReportFixture.getVehicle()));
 
-			DamageReport damageReport = registerDamageReportRequest.toEntity(damageReportFixture.getVehicle());
+			DamageReport damageReport = registerDamageReportRequest.toEntity(damageReportFixture.getVehicle(), userId);
 			ReflectionTestUtils.setField(damageReport, "id", 1L);
 			Mockito.when(damageReportRepository.save(Mockito.any(DamageReport.class))).thenReturn(damageReport);
 
 		    //when
-			Long result = damageReportService.register(registerDamageReportRequest, vehicleId);
+			Long result = damageReportService.register(registerDamageReportRequest, userId);
 
 			//then
 			Mockito.verify(damageReportRepository, Mockito.times(1))

--- a/src/test/java/com/carumuch/capstone/damage/integration/DamageReportIntegrationTest.java
+++ b/src/test/java/com/carumuch/capstone/damage/integration/DamageReportIntegrationTest.java
@@ -119,7 +119,8 @@ public class DamageReportIntegrationTest extends IntegrationSupportTest {
 					damageReport.getPreferredRepairRegion(),
 					damageReport.isPickupRequired(),
 					damageReport.getImagePath(),
-					vehicle
+					vehicle,
+					user.getId()
 				)
 			).getId();
 
@@ -178,7 +179,8 @@ public class DamageReportIntegrationTest extends IntegrationSupportTest {
 						damageReport.getPreferredRepairRegion(),
 						damageReport.isPickupRequired(),
 						damageReport.getImagePath(),
-						vehicle
+						vehicle,
+						user.getId()
 					))
 				).toList();
 
@@ -217,7 +219,8 @@ public class DamageReportIntegrationTest extends IntegrationSupportTest {
 						damageReport.getPreferredRepairRegion(),
 						damageReport.isPickupRequired(),
 						damageReport.getImagePath(),
-						vehicle
+						vehicle,
+						user.getId()
 					))
 				).toList();
 

--- a/src/test/java/com/carumuch/capstone/damage/presentation/DamageReportControllerTest.java
+++ b/src/test/java/com/carumuch/capstone/damage/presentation/DamageReportControllerTest.java
@@ -40,7 +40,6 @@ class DamageReportControllerTest extends RestDocsSupport {
 
 	private static final String BASE_URI = "/damage-reports";
 	private static final String BASE_TAG = "Damage - Report";
-	private static final String BASE_SUCCESS_MESSAGE = "OK";
 
 	@Nested
 	@DisplayName("사고 레포트 등록 API 테스트")

--- a/src/test/java/com/carumuch/capstone/damage/presentation/VehicleControllerTest.java
+++ b/src/test/java/com/carumuch/capstone/damage/presentation/VehicleControllerTest.java
@@ -35,7 +35,6 @@ class VehicleControllerTest extends RestDocsSupport {
 
 	private static final String BASE_URI = "/vehicles";
 	private static final String BASE_TAG = "Damage - Vehicle";
-	private static final String BASE_SUCCESS_MESSAGE = "OK";
 
 	@Nested
 	@DisplayName("차량 등록 API 테스트")

--- a/src/test/java/com/carumuch/capstone/estimate/application/EstimateServiceTest.java
+++ b/src/test/java/com/carumuch/capstone/estimate/application/EstimateServiceTest.java
@@ -3,6 +3,7 @@ package com.carumuch.capstone.estimate.application;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.assertj.core.api.Assertions;
@@ -14,13 +15,21 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import com.carumuch.capstone.common.exception.CustomException;
 import com.carumuch.capstone.common.exception.NotFoundException;
+import com.carumuch.capstone.common.presentation.dto.PagingRequest;
+import com.carumuch.capstone.common.presentation.dto.PagingResponse;
+import com.carumuch.capstone.estimate.application.dto.EstimateSearchCondition;
 import com.carumuch.capstone.estimate.domain.Estimate;
 import com.carumuch.capstone.estimate.domain.EstimateRepository;
 import com.carumuch.capstone.estimate.domain.EstimateStatus;
+import com.carumuch.capstone.estimate.presentation.dto.request.SearchEstimateRequest;
 import com.carumuch.capstone.estimate.presentation.dto.response.EstimateDetailResponse;
 import com.carumuch.capstone.support.fixture.EstimateFixture;
 
@@ -252,6 +261,88 @@ class EstimateServiceTest {
 		    //when & then
 			assertThatThrownBy(() -> estimateService.changeStatus(estimateId, estimateStatus))
 				.isInstanceOf(CustomException.class);
+		}
+	}
+
+	@Nested
+	@DisplayName("견적서 조건 검색 기능")
+	class SearchEstimates {
+		@Test
+		void 견적서를_조회한다() {
+		    //given
+			SearchEstimateRequest searchEstimateRequest = new SearchEstimateRequest(
+				null, null, null, null, null, null, null, null
+			);
+
+			EstimateSearchCondition estimateSearchCondition = EstimateSearchCondition.from(searchEstimateRequest);
+
+			PagingRequest pagingRequest = new PagingRequest(null, null, null);
+			PageRequest pageRequest = PageRequest.of(pagingRequest.page(), pagingRequest.size(),
+				Sort.by(pagingRequest.sort()));
+
+			List<Estimate> estimateList = List.of(
+				EstimateFixture.ESTIMATE_FIXTURE_1.create(),
+				EstimateFixture.ESTIMATE_FIXTURE_2.create()
+			);
+			PageImpl<Estimate> estimates = new PageImpl<>(estimateList, pageRequest, estimateList.size());
+
+			Mockito.when(estimateRepository.searchEstimates(estimateSearchCondition, pageRequest))
+				.thenReturn(estimates);
+
+			//when
+			estimateService.searchEstimates(searchEstimateRequest, pagingRequest);
+
+		    //then
+			Mockito.verify(estimateRepository, Mockito.times(1))
+				.searchEstimates(estimateSearchCondition, pageRequest);
+		}
+
+		@Test
+		void 견적서를_인기순으로_조회한다() {
+			//given
+			SearchEstimateRequest searchEstimateRequest = new SearchEstimateRequest(
+				null, null, null, null, null, null, null, null
+			);
+
+			EstimateSearchCondition estimateSearchCondition = EstimateSearchCondition.from(searchEstimateRequest);
+
+			PagingRequest pagingRequest = new PagingRequest(null, null, "POPULOR");
+			PageRequest pageRequest = PageRequest.of(pagingRequest.page(), pagingRequest.size(),
+				Sort.by(pagingRequest.sort()));
+
+			Estimate midPopularityEstimate = EstimateFixture.ESTIMATE_FIXTURE_1.create();
+			ReflectionTestUtils.setField(midPopularityEstimate, "id", 1_000L);
+			ReflectionTestUtils.setField(midPopularityEstimate, "applicantCount", 100);
+
+			Estimate lowPopularityEstimate = EstimateFixture.ESTIMATE_FIXTURE_1.create();
+			ReflectionTestUtils.setField(midPopularityEstimate, "id", 2_000L);
+			ReflectionTestUtils.setField(lowPopularityEstimate, "applicantCount", 50);
+
+			Estimate highPopularityEstimate = EstimateFixture.ESTIMATE_FIXTURE_1.create();
+			ReflectionTestUtils.setField(midPopularityEstimate, "id", 3_000L);
+			ReflectionTestUtils.setField(highPopularityEstimate, "applicantCount", 200);
+
+			List<Estimate> estimateList = List.of(
+				highPopularityEstimate,
+				midPopularityEstimate,
+				lowPopularityEstimate
+			);
+			PageImpl<Estimate> estimates = new PageImpl<>(estimateList, pageRequest, estimateList.size());
+
+			Mockito.when(estimateRepository.searchEstimates(estimateSearchCondition, pageRequest))
+				.thenReturn(estimates);
+
+			//when
+			PagingResponse<EstimateDetailResponse> result = estimateService.searchEstimates(
+				searchEstimateRequest, pagingRequest);
+
+			//then
+			assertAll(
+				() -> Assertions.assertThat(result.content().size()).isEqualTo(3),
+				() -> Assertions.assertThat(result.content().get(0).estimateId()).isEqualTo(highPopularityEstimate.getId()),
+				() -> Assertions.assertThat(result.content().get(1).estimateId()).isEqualTo(midPopularityEstimate.getId()),
+				() -> Assertions.assertThat(result.content().get(2).estimateId()).isEqualTo(lowPopularityEstimate.getId())
+			);
 		}
 	}
 }

--- a/src/test/java/com/carumuch/capstone/estimate/application/EstimateServiceTest.java
+++ b/src/test/java/com/carumuch/capstone/estimate/application/EstimateServiceTest.java
@@ -306,7 +306,7 @@ class EstimateServiceTest {
 
 			EstimateSearchCondition estimateSearchCondition = EstimateSearchCondition.from(searchEstimateRequest);
 
-			PagingRequest pagingRequest = new PagingRequest(null, null, "POPULOR");
+			PagingRequest pagingRequest = new PagingRequest(null, null, "POPULAR");
 			PageRequest pageRequest = PageRequest.of(pagingRequest.page(), pagingRequest.size(),
 				Sort.by(pagingRequest.sort()));
 
@@ -315,11 +315,11 @@ class EstimateServiceTest {
 			ReflectionTestUtils.setField(midPopularityEstimate, "applicantCount", 100);
 
 			Estimate lowPopularityEstimate = EstimateFixture.ESTIMATE_FIXTURE_1.create();
-			ReflectionTestUtils.setField(midPopularityEstimate, "id", 2_000L);
+			ReflectionTestUtils.setField(lowPopularityEstimate, "id", 2_000L);
 			ReflectionTestUtils.setField(lowPopularityEstimate, "applicantCount", 50);
 
 			Estimate highPopularityEstimate = EstimateFixture.ESTIMATE_FIXTURE_1.create();
-			ReflectionTestUtils.setField(midPopularityEstimate, "id", 3_000L);
+			ReflectionTestUtils.setField(highPopularityEstimate, "id", 3_000L);
 			ReflectionTestUtils.setField(highPopularityEstimate, "applicantCount", 200);
 
 			List<Estimate> estimateList = List.of(

--- a/src/test/java/com/carumuch/capstone/estimate/application/EstimateServiceTest.java
+++ b/src/test/java/com/carumuch/capstone/estimate/application/EstimateServiceTest.java
@@ -22,6 +22,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import com.carumuch.capstone.common.exception.CustomException;
+import com.carumuch.capstone.common.exception.ForbiddenException;
 import com.carumuch.capstone.common.exception.NotFoundException;
 import com.carumuch.capstone.common.presentation.dto.PagingRequest;
 import com.carumuch.capstone.common.presentation.dto.PagingResponse;
@@ -31,7 +32,9 @@ import com.carumuch.capstone.estimate.domain.EstimateRepository;
 import com.carumuch.capstone.estimate.domain.EstimateStatus;
 import com.carumuch.capstone.estimate.presentation.dto.request.SearchEstimateRequest;
 import com.carumuch.capstone.estimate.presentation.dto.response.EstimateDetailResponse;
+import com.carumuch.capstone.identity.domain.user.User;
 import com.carumuch.capstone.support.fixture.EstimateFixture;
+import com.carumuch.capstone.support.fixture.UserFixture;
 
 @ExtendWith(MockitoExtension.class)
 class EstimateServiceTest {
@@ -209,8 +212,8 @@ class EstimateServiceTest {
 			Mockito.when(estimateRepository.findById(estimateId))
 				.thenReturn(Optional.of(estimateFixture));
 
-		    //when
-			estimateService.changeStatus(estimateId, estimateStatus);
+			//when
+			estimateService.changeStatus(estimateId, estimateStatus, estimateFixture.getUserId());
 
 		    //then
 			Mockito.verify(estimateRepository, Mockito.times(1))
@@ -221,12 +224,13 @@ class EstimateServiceTest {
 		void 견적서를_찾지_못하면_예외를_반환한다() {
 		    //given
 			Long estimateId = 300L;
+			Long userId = 10L;
 			String estimateStatus = EstimateStatus.PRIVATE.name();
 			Mockito.when(estimateRepository.findById(estimateId))
 				.thenReturn(Optional.empty());
 
 		    //when & then
-			assertThatThrownBy(() -> estimateService.changeStatus(estimateId, estimateStatus))
+			assertThatThrownBy(() -> estimateService.changeStatus(estimateId, estimateStatus, userId))
 				.isInstanceOf(NotFoundException.class);
 		}
 
@@ -242,7 +246,7 @@ class EstimateServiceTest {
 				.thenReturn(Optional.of(estimateFixture));
 
 		    //when
-			estimateService.changeStatus(estimateId, estimateStatus);
+			estimateService.changeStatus(estimateId, estimateStatus, estimateFixture.getUserId());
 
 		    //then
 			Assertions.assertThat(estimateFixture.getEstimateStatus()).isEqualTo(EstimateStatus.valueOf(estimateStatus));
@@ -259,8 +263,24 @@ class EstimateServiceTest {
 				.thenReturn(Optional.of(alreadyMatchedEstimateFixture));
 
 		    //when & then
-			assertThatThrownBy(() -> estimateService.changeStatus(estimateId, estimateStatus))
+			assertThatThrownBy(() -> estimateService.changeStatus(estimateId, estimateStatus, alreadyMatchedEstimateFixture.getUserId()))
 				.isInstanceOf(CustomException.class);
+		}
+
+		@Test
+		void 자신의_견적서가_아니라면_수정할_수_없다() {
+			//given
+			Long estimateId = 300L;
+			Estimate estimateFixture = EstimateFixture.ESTIMATE_FIXTURE_1.create();
+			String estimateStatus = EstimateStatus.PRIVATE.name();
+			Mockito.when(estimateRepository.findById(estimateId))
+				.thenReturn(Optional.of(estimateFixture));
+
+			Long anotherUserId = 20L;
+
+			//when & then
+			assertThatThrownBy(() -> estimateService.changeStatus(estimateId, estimateStatus, anotherUserId))
+				.isInstanceOf(ForbiddenException.class);
 		}
 	}
 

--- a/src/test/java/com/carumuch/capstone/estimate/application/EstimateServiceTest.java
+++ b/src/test/java/com/carumuch/capstone/estimate/application/EstimateServiceTest.java
@@ -282,6 +282,21 @@ class EstimateServiceTest {
 			assertThatThrownBy(() -> estimateService.changeStatus(estimateId, estimateStatus, anotherUserId))
 				.isInstanceOf(ForbiddenException.class);
 		}
+
+		@Test
+		void 견적서를_낙찰된_상태로_변경할_수_없다() {
+		    //given
+			Long estimateId = 300L;
+			Estimate estimateFixture = EstimateFixture.ESTIMATE_FIXTURE_1.create();
+			String estimateStatus = EstimateStatus.CLOSED.name();
+
+			Mockito.when(estimateRepository.findById(estimateId))
+				.thenReturn(Optional.of(estimateFixture));
+
+		    //when & then
+			assertThatThrownBy(() -> estimateService.changeStatus(estimateId, estimateStatus, estimateFixture.getUserId()))
+				.isInstanceOf(CustomException.class);
+		}
 	}
 
 	@Nested

--- a/src/test/java/com/carumuch/capstone/estimate/application/EstimateServiceTest.java
+++ b/src/test/java/com/carumuch/capstone/estimate/application/EstimateServiceTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.Optional;
 
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -15,9 +16,11 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import com.carumuch.capstone.common.exception.CustomException;
 import com.carumuch.capstone.common.exception.NotFoundException;
 import com.carumuch.capstone.estimate.domain.Estimate;
 import com.carumuch.capstone.estimate.domain.EstimateRepository;
+import com.carumuch.capstone.estimate.domain.EstimateStatus;
 import com.carumuch.capstone.estimate.presentation.dto.response.EstimateDetailResponse;
 import com.carumuch.capstone.support.fixture.EstimateFixture;
 
@@ -106,4 +109,71 @@ class EstimateServiceTest {
 		}
 	}
 
+	@Nested
+	@DisplayName("견적서 상태 업데이트 기능")
+	class UpdateEstimateStatus {
+		@Test
+		void 견적서_PK로_견적서를_조회한다() {
+		    //given
+			Long estimateId = 300L;
+			String estimateStatus = EstimateStatus.PRIVATE.name();
+
+			Estimate estimateFixture = EstimateFixture.ESTIMATE_FIXTURE_1.create();
+			Mockito.when(estimateRepository.findById(estimateId))
+				.thenReturn(Optional.of(estimateFixture));
+
+		    //when
+			estimateService.changeStatus(estimateId, estimateStatus);
+
+		    //then
+			Mockito.verify(estimateRepository, Mockito.times(1))
+				.findById(estimateId);
+		}
+
+		@Test
+		void 견적서를_찾지_못하면_예외를_반환한다() {
+		    //given
+			Long estimateId = 300L;
+			String estimateStatus = EstimateStatus.PRIVATE.name();
+			Mockito.when(estimateRepository.findById(estimateId))
+				.thenReturn(Optional.empty());
+
+		    //when & then
+			assertThatThrownBy(() -> estimateService.changeStatus(estimateId, estimateStatus))
+				.isInstanceOf(NotFoundException.class);
+		}
+
+		@Test
+		void 견적서_상태를_업데이트_한다() {
+		    //given
+			Long estimateId = 300L;
+			String estimateStatus = EstimateStatus.PRIVATE.name();
+
+			Estimate estimateFixture = EstimateFixture.ESTIMATE_FIXTURE_1.create();
+
+			Mockito.when(estimateRepository.findById(estimateId))
+				.thenReturn(Optional.of(estimateFixture));
+
+		    //when
+			estimateService.changeStatus(estimateId, estimateStatus);
+
+		    //then
+			Assertions.assertThat(estimateFixture.getEstimateStatus()).isEqualTo(EstimateStatus.valueOf(estimateStatus));
+		}
+
+		@Test
+		void 이미_매칭된_견적서의_상태를_변경하면_예외를_반환한다() {
+		    //given
+			Long estimateId = 300L;
+			String estimateStatus = EstimateStatus.PRIVATE.name();
+
+			Estimate alreadyMatchedEstimateFixture = EstimateFixture.ESTIMATE_FIXTURE_2.create();
+			Mockito.when(estimateRepository.findById(estimateId))
+				.thenReturn(Optional.of(alreadyMatchedEstimateFixture));
+
+		    //when & then
+			assertThatThrownBy(() -> estimateService.changeStatus(estimateId, estimateStatus))
+				.isInstanceOf(CustomException.class);
+		}
+	}
 }

--- a/src/test/java/com/carumuch/capstone/estimate/application/EstimateServiceTest.java
+++ b/src/test/java/com/carumuch/capstone/estimate/application/EstimateServiceTest.java
@@ -1,0 +1,109 @@
+package com.carumuch.capstone.estimate.application;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.carumuch.capstone.common.exception.NotFoundException;
+import com.carumuch.capstone.estimate.domain.Estimate;
+import com.carumuch.capstone.estimate.domain.EstimateRepository;
+import com.carumuch.capstone.estimate.presentation.dto.response.EstimateDetailResponse;
+import com.carumuch.capstone.support.fixture.EstimateFixture;
+
+@ExtendWith(MockitoExtension.class)
+class EstimateServiceTest {
+
+	@InjectMocks
+	EstimateService estimateService;
+
+	@Mock
+	EstimateRepository estimateRepository;
+
+	@Nested
+	@DisplayName("견적서 상세 조회 기능")
+	class FindEstimateDetail {
+		@Test
+		void 견적서_PK로_견적서를_조회한다() {
+		    //given
+			Long estimateId = 300L;
+			Estimate estimateFixture = EstimateFixture.ESTIMATE_FIXTURE_1.create();
+			Mockito.when(estimateRepository.findDetailById(estimateId))
+				.thenReturn(Optional.of(estimateFixture));
+
+		    //when
+		    estimateService.findEstimateDetail(estimateId);
+
+		    //then
+			Mockito.verify(estimateRepository, Mockito.times(1))
+				.findDetailById(estimateId);
+		}
+
+		@Test
+		void 견적서가_존재하지_않는다면_예외를_반환한다() {
+		    //given
+			Long estimateId = 300L;
+			Mockito.when(estimateRepository.findDetailById(estimateId))
+				.thenReturn(Optional.empty());
+
+		    //when & then
+			assertThatThrownBy(() -> estimateService.findEstimateDetail(estimateId))
+				.isInstanceOf(NotFoundException.class);
+		}
+
+		@Test
+		void 견적서_상세_정보를_응답한다() {
+		    //given
+			Long estimateId = 300L;
+
+			Estimate estimateFixture = EstimateFixture.ESTIMATE_FIXTURE_1.create();
+			ReflectionTestUtils.setField(estimateFixture, "id", estimateId);
+
+			Mockito.when(estimateRepository.findDetailById(estimateId))
+				.thenReturn(Optional.of(estimateFixture));
+
+			EstimateDetailResponse estimateDetailResponse = new EstimateDetailResponse(estimateFixture);
+
+		    //when
+			EstimateDetailResponse result = estimateService.findEstimateDetail(estimateId);
+
+			//then
+			assertAll(
+				() -> assertThat(result.estimateId()).isEqualTo(estimateDetailResponse.estimateId()),
+				() -> assertThat(result.repairCost()).isEqualTo(estimateDetailResponse.repairCost()),
+				() -> assertThat(result.repairParts().get(0)).isEqualTo(estimateDetailResponse.repairParts().get(0)),
+				() -> assertThat(result.repairParts().get(1)).isEqualTo(estimateDetailResponse.repairParts().get(1)),
+				() -> assertThat(result.repairParts().get(2)).isEqualTo(estimateDetailResponse.repairParts().get(2)),
+				() -> assertThat(result.estimateStatus()).isEqualTo(estimateDetailResponse.estimateStatus()),
+				() -> assertThat(result.imagePath()).isEqualTo(estimateDetailResponse.imagePath())
+			);
+
+			assertAll(
+				() -> assertThat(result.vehicleInfo().brand()).isEqualTo(estimateDetailResponse.vehicleInfo().brand()),
+				() -> assertThat(result.vehicleInfo().licenseNumber()).isEqualTo(estimateDetailResponse.vehicleInfo().licenseNumber()),
+				() -> assertThat(result.vehicleInfo().modelName()).isEqualTo(estimateDetailResponse.vehicleInfo().modelName()),
+				() -> assertThat(result.vehicleInfo().modelYear()).isEqualTo(estimateDetailResponse.vehicleInfo().modelYear()),
+				() -> assertThat(result.vehicleInfo().ownerName()).isEqualTo(estimateDetailResponse.vehicleInfo().ownerName()),
+				() -> assertThat(result.vehicleInfo().ownershipType()).isEqualTo(estimateDetailResponse.vehicleInfo().ownershipType())
+			);
+
+			assertAll(
+				() -> assertThat(result.damageReportInfo().description()).isEqualTo(estimateDetailResponse.damageReportInfo().description()),
+				() -> assertThat(result.damageReportInfo().preferredRepairSido()).isEqualTo(estimateDetailResponse.damageReportInfo().preferredRepairSido()),
+				() -> assertThat(result.damageReportInfo().preferredRepairSigungu()).isEqualTo(estimateDetailResponse.damageReportInfo().preferredRepairSigungu()),
+				() -> assertThat(result.damageReportInfo().isPickupRequired()).isEqualTo(estimateDetailResponse.damageReportInfo().isPickupRequired())
+			);
+		}
+	}
+
+}

--- a/src/test/java/com/carumuch/capstone/estimate/application/EstimateServiceTest.java
+++ b/src/test/java/com/carumuch/capstone/estimate/application/EstimateServiceTest.java
@@ -110,6 +110,84 @@ class EstimateServiceTest {
 	}
 
 	@Nested
+	@DisplayName("사고 레포트를 통한 견적서 상세 조회 기능")
+	class FindEstimateDetailByDamageReportId {
+		@Test
+		void 사고레포트_PK로_견적서를_조회한다() {
+			//given
+			Long damageReportId = 200L;
+			Estimate estimateFixture = EstimateFixture.ESTIMATE_FIXTURE_1.create();
+			Mockito.when(estimateRepository.findDetailByDamageReportId(damageReportId))
+				.thenReturn(Optional.of(estimateFixture));
+
+			//when
+			estimateService.findEstimateDetailByDamageReportId(damageReportId);
+
+			//then
+			Mockito.verify(estimateRepository, Mockito.times(1))
+				.findDetailByDamageReportId(damageReportId);
+		}
+
+		@Test
+		void 견적서가_존재하지_않는다면_예외를_반환한다() {
+			//given
+			Long damageReportId = 200L;
+			Mockito.when(estimateRepository.findDetailByDamageReportId(damageReportId))
+				.thenReturn(Optional.empty());
+
+			//when & then
+			assertThatThrownBy(() -> estimateService.findEstimateDetailByDamageReportId(damageReportId))
+				.isInstanceOf(NotFoundException.class);
+		}
+
+		@Test
+		void 견적서_상세_정보를_응답한다() {
+			//given
+			Long damageReportId = 200L;
+
+			Estimate estimateFixture = EstimateFixture.ESTIMATE_FIXTURE_1.create();
+
+			Long estimateId = 300L;
+			ReflectionTestUtils.setField(estimateFixture, "id", estimateId);
+
+			Mockito.when(estimateRepository.findDetailByDamageReportId(damageReportId))
+				.thenReturn(Optional.of(estimateFixture));
+
+			EstimateDetailResponse estimateDetailResponse = new EstimateDetailResponse(estimateFixture);
+
+			//when
+			EstimateDetailResponse result = estimateService.findEstimateDetailByDamageReportId(damageReportId);
+
+			//then
+			assertAll(
+				() -> assertThat(result.estimateId()).isEqualTo(estimateDetailResponse.estimateId()),
+				() -> assertThat(result.repairCost()).isEqualTo(estimateDetailResponse.repairCost()),
+				() -> assertThat(result.repairParts().get(0)).isEqualTo(estimateDetailResponse.repairParts().get(0)),
+				() -> assertThat(result.repairParts().get(1)).isEqualTo(estimateDetailResponse.repairParts().get(1)),
+				() -> assertThat(result.repairParts().get(2)).isEqualTo(estimateDetailResponse.repairParts().get(2)),
+				() -> assertThat(result.estimateStatus()).isEqualTo(estimateDetailResponse.estimateStatus()),
+				() -> assertThat(result.imagePath()).isEqualTo(estimateDetailResponse.imagePath())
+			);
+
+			assertAll(
+				() -> assertThat(result.vehicleInfo().brand()).isEqualTo(estimateDetailResponse.vehicleInfo().brand()),
+				() -> assertThat(result.vehicleInfo().licenseNumber()).isEqualTo(estimateDetailResponse.vehicleInfo().licenseNumber()),
+				() -> assertThat(result.vehicleInfo().modelName()).isEqualTo(estimateDetailResponse.vehicleInfo().modelName()),
+				() -> assertThat(result.vehicleInfo().modelYear()).isEqualTo(estimateDetailResponse.vehicleInfo().modelYear()),
+				() -> assertThat(result.vehicleInfo().ownerName()).isEqualTo(estimateDetailResponse.vehicleInfo().ownerName()),
+				() -> assertThat(result.vehicleInfo().ownershipType()).isEqualTo(estimateDetailResponse.vehicleInfo().ownershipType())
+			);
+
+			assertAll(
+				() -> assertThat(result.damageReportInfo().description()).isEqualTo(estimateDetailResponse.damageReportInfo().description()),
+				() -> assertThat(result.damageReportInfo().preferredRepairSido()).isEqualTo(estimateDetailResponse.damageReportInfo().preferredRepairSido()),
+				() -> assertThat(result.damageReportInfo().preferredRepairSigungu()).isEqualTo(estimateDetailResponse.damageReportInfo().preferredRepairSigungu()),
+				() -> assertThat(result.damageReportInfo().isPickupRequired()).isEqualTo(estimateDetailResponse.damageReportInfo().isPickupRequired())
+			);
+		}
+	}
+
+	@Nested
 	@DisplayName("견적서 상태 업데이트 기능")
 	class UpdateEstimateStatus {
 		@Test

--- a/src/test/java/com/carumuch/capstone/estimate/integration/EstimateIntegrationTest.java
+++ b/src/test/java/com/carumuch/capstone/estimate/integration/EstimateIntegrationTest.java
@@ -244,10 +244,10 @@ public class EstimateIntegrationTest extends IntegrationSupportTest {
 		@Test
 		void 이미_매칭된_견적서의_상태를_변경하면_예외를_반환한다() {
 		    //given
-			Estimate closedEstimate = estimateRepository.save(EstimateFixture.ESTIMATE_FIXTURE_2.create());
+			estimate.closeBidding();
 
 			//when & then
-			assertThatThrownBy(() -> estimateService.changeStatus(closedEstimate.getId(), EstimateStatus.PRIVATE.name(), user.getId()))
+			assertThatThrownBy(() -> estimateService.changeStatus(estimate.getId(), EstimateStatus.PRIVATE.name(), user.getId()))
 				.isInstanceOf(CustomException.class);
 		}
 

--- a/src/test/java/com/carumuch/capstone/estimate/integration/EstimateIntegrationTest.java
+++ b/src/test/java/com/carumuch/capstone/estimate/integration/EstimateIntegrationTest.java
@@ -261,6 +261,16 @@ public class EstimateIntegrationTest extends IntegrationSupportTest {
 			assertThatThrownBy(() -> estimateService.changeStatus(estimate.getId(), EstimateStatus.PRIVATE.name(), anotherUserId))
 				.isInstanceOf(ForbiddenException.class);
 		}
+
+		@Test
+		void 견적서를_낙찰된_상태로_변경할_수_없다() {
+		    //given
+			String estimateStatus = EstimateStatus.CLOSED.name();
+
+		    //when & then
+		    assertThatThrownBy(() -> estimateService.changeStatus(estimate.getId(), estimateStatus, user.getId()))
+				.isInstanceOf(CustomException.class);
+		}
 	}
 
 	@Nested

--- a/src/test/java/com/carumuch/capstone/estimate/integration/EstimateIntegrationTest.java
+++ b/src/test/java/com/carumuch/capstone/estimate/integration/EstimateIntegrationTest.java
@@ -19,7 +19,6 @@ import com.carumuch.capstone.damage.domain.report.DamageReportRepository;
 import com.carumuch.capstone.damage.domain.vehicle.Vehicle;
 import com.carumuch.capstone.damage.domain.vehicle.VehicleRepository;
 import com.carumuch.capstone.estimate.application.EstimateService;
-import com.carumuch.capstone.estimate.application.dto.EstimateSearchCondition;
 import com.carumuch.capstone.estimate.domain.Estimate;
 import com.carumuch.capstone.estimate.domain.EstimateRepository;
 import com.carumuch.capstone.estimate.domain.EstimateStatus;
@@ -306,7 +305,6 @@ public class EstimateIntegrationTest extends IntegrationSupportTest {
 				null, null, null, null, null, null, null, null
 			);
 
-			EstimateSearchCondition estimateSearchCondition = EstimateSearchCondition.from(searchEstimateRequest);
 			PagingRequest pagingRequest = new PagingRequest(null, null, null);
 
 

--- a/src/test/java/com/carumuch/capstone/estimate/integration/EstimateIntegrationTest.java
+++ b/src/test/java/com/carumuch/capstone/estimate/integration/EstimateIntegrationTest.java
@@ -11,14 +11,18 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import com.carumuch.capstone.common.exception.CustomException;
 import com.carumuch.capstone.common.exception.NotFoundException;
+import com.carumuch.capstone.common.presentation.dto.PagingRequest;
+import com.carumuch.capstone.common.presentation.dto.PagingResponse;
 import com.carumuch.capstone.damage.domain.report.DamageReport;
 import com.carumuch.capstone.damage.domain.report.DamageReportRepository;
 import com.carumuch.capstone.damage.domain.vehicle.Vehicle;
 import com.carumuch.capstone.damage.domain.vehicle.VehicleRepository;
 import com.carumuch.capstone.estimate.application.EstimateService;
+import com.carumuch.capstone.estimate.application.dto.EstimateSearchCondition;
 import com.carumuch.capstone.estimate.domain.Estimate;
 import com.carumuch.capstone.estimate.domain.EstimateRepository;
 import com.carumuch.capstone.estimate.domain.EstimateStatus;
+import com.carumuch.capstone.estimate.presentation.dto.request.SearchEstimateRequest;
 import com.carumuch.capstone.estimate.presentation.dto.response.EstimateDetailResponse;
 import com.carumuch.capstone.identity.domain.user.User;
 import com.carumuch.capstone.identity.domain.user.UserRepository;
@@ -243,6 +247,56 @@ public class EstimateIntegrationTest extends IntegrationSupportTest {
 			//when & then
 			assertThatThrownBy(() -> estimateService.changeStatus(closedEstimate.getId(), EstimateStatus.PRIVATE.name()))
 				.isInstanceOf(CustomException.class);
+		}
+	}
+
+	@Nested
+	@DisplayName("견적서 조건 검색 기능")
+	class SearchEstimates {
+		@Test
+		void 견적서를_조회한다() {
+		    //given
+			DamageReport damageReportFixture = DamageReportFixture.DAMAGE_REPORT_FIXTURE_1.create();
+			DamageReport damageReport = damageReportRepository.save(
+				new DamageReport(
+					damageReportFixture.getDescription(),
+					damageReportFixture.getPreferredRepairRegion(),
+					damageReportFixture.isPickupRequired(),
+					damageReportFixture.getImagePath(),
+					vehicle
+				)
+			);
+
+			Estimate estimateFixture2 = EstimateFixture.ESTIMATE_FIXTURE_4.create();
+			Estimate estimate2 = estimateRepository.save(
+				new Estimate(
+					estimateFixture2.getRepairCost(),
+					estimateFixture2.getRepairParts(),
+					estimateFixture2.getEstimateStatus(),
+					estimateFixture2.getImagePath(),
+					damageReport
+				)
+			);
+
+			SearchEstimateRequest searchEstimateRequest = new SearchEstimateRequest(
+				null, null, null, null, null, null, null, null
+			);
+
+			EstimateSearchCondition estimateSearchCondition = EstimateSearchCondition.from(searchEstimateRequest);
+			PagingRequest pagingRequest = new PagingRequest(null, null, null);
+
+
+		    //when
+			PagingResponse<EstimateDetailResponse> result = estimateService.searchEstimates(
+				searchEstimateRequest, pagingRequest);
+
+			//then
+			assertAll(
+				() -> assertThat(result.content().get(0).estimateId()).isEqualTo(estimate.getId()),
+				() -> assertThat(result.content().get(0).imagePath()).isEqualTo(estimate.getImagePath()),
+				() -> assertThat(result.content().get(1).estimateId()).isEqualTo(estimate2.getId()),
+				() -> assertThat(result.content().get(1).imagePath()).isEqualTo(estimate2.getImagePath())
+			);
 		}
 	}
 }

--- a/src/test/java/com/carumuch/capstone/estimate/integration/EstimateIntegrationTest.java
+++ b/src/test/java/com/carumuch/capstone/estimate/integration/EstimateIntegrationTest.java
@@ -169,7 +169,7 @@ public class EstimateIntegrationTest extends IntegrationSupportTest {
 			assertAll(
 				() -> assertThat(estimateDetail.estimateId()).isEqualTo(result.getId()),
 				() -> assertThat(estimateDetail.estimateStatus()).isEqualTo(result.getEstimateStatus().name()),
-				() -> assertThat(estimateDetail.estimateId()).isEqualTo(result.getId()),
+				() -> assertThat(estimateDetail.imagePath()).isEqualTo(result.getImagePath()),
 				() -> assertThat(estimateDetail.repairCost()).isEqualTo(result.getRepairCost()),
 				() -> assertThat(estimateDetail.repairParts().size()).isEqualTo(result.getRepairParts().size())
 			);

--- a/src/test/java/com/carumuch/capstone/estimate/integration/EstimateIntegrationTest.java
+++ b/src/test/java/com/carumuch/capstone/estimate/integration/EstimateIntegrationTest.java
@@ -61,7 +61,7 @@ public class EstimateIntegrationTest extends IntegrationSupportTest {
 		);
 
 		Vehicle vehicleFixture = VehicleFixture.VEHICLE_FIXTURE_1.create();
-		Vehicle vehicle = vehicleRepository.save(
+		vehicle = vehicleRepository.save(
 			new Vehicle(
 				vehicleFixture.getLicenseNumber().getValue(),
 				vehicleFixture.getOwnershipType(),
@@ -74,7 +74,7 @@ public class EstimateIntegrationTest extends IntegrationSupportTest {
 		);
 
 		DamageReport damageReportFixture = DamageReportFixture.DAMAGE_REPORT_FIXTURE_1.create();
-		DamageReport damageReport = damageReportRepository.save(
+		damageReport = damageReportRepository.save(
 			new DamageReport(
 				damageReportFixture.getDescription(),
 				damageReportFixture.getPreferredRepairRegion(),
@@ -141,6 +141,55 @@ public class EstimateIntegrationTest extends IntegrationSupportTest {
 
 		    //when & then
 			assertThatThrownBy(() -> estimateService.findEstimateDetail(noSavedEstimateId))
+				.isInstanceOf(NotFoundException.class);
+		}
+	}
+
+	@Nested
+	@DisplayName("사고 레포트를 통한 견적서 상세 조회 기능")
+	class FindEstimateDetailByDamageReportId {
+		@Test
+		void 사고_레포트를_통한_견적서_상세_조회_기능() {
+			//given
+			Long damageReportId = damageReport.getId();
+
+			//when
+			EstimateDetailResponse estimateDetail = estimateService.findEstimateDetailByDamageReportId(damageReportId);
+
+			//then
+			Estimate result = estimateRepository.findDetailByDamageReportId(damageReportId)
+				.orElseThrow(() -> new AssertionError("estimate not found"));
+
+			assertAll(
+				() -> assertThat(estimateDetail.estimateId()).isEqualTo(result.getId()),
+				() -> assertThat(estimateDetail.estimateStatus()).isEqualTo(result.getEstimateStatus().name()),
+				() -> assertThat(estimateDetail.estimateId()).isEqualTo(result.getId()),
+				() -> assertThat(estimateDetail.repairCost()).isEqualTo(result.getRepairCost()),
+				() -> assertThat(estimateDetail.repairParts().size()).isEqualTo(result.getRepairParts().size())
+			);
+			assertAll(
+				() -> assertThat(estimateDetail.damageReportInfo().isPickupRequired()).isEqualTo(result.getDamageReport().isPickupRequired()),
+				() -> assertThat(estimateDetail.damageReportInfo().preferredRepairSido()).isEqualTo(result.getDamageReport().getPreferredRepairRegion().getSido()),
+				() -> assertThat(estimateDetail.damageReportInfo().preferredRepairSigungu()).isEqualTo(result.getDamageReport().getPreferredRepairRegion().getSigungu()),
+				() -> assertThat(estimateDetail.damageReportInfo().description()).isEqualTo(result.getDamageReport().getDescription())
+			);
+			assertAll(
+				() -> assertThat(estimateDetail.vehicleInfo().brand()).isEqualTo(result.getDamageReport().getVehicle().getBrand()),
+				() -> assertThat(estimateDetail.vehicleInfo().ownershipType()).isEqualTo(result.getDamageReport().getVehicle().getOwnershipType().name()),
+				() -> assertThat(estimateDetail.vehicleInfo().ownerName()).isEqualTo(result.getDamageReport().getVehicle().getOwnerName()),
+				() -> assertThat(estimateDetail.vehicleInfo().modelName()).isEqualTo(result.getDamageReport().getVehicle().getModelName()),
+				() -> assertThat(estimateDetail.vehicleInfo().modelYear()).isEqualTo(result.getDamageReport().getVehicle().getModelYear()),
+				() -> assertThat(estimateDetail.vehicleInfo().licenseNumber()).isEqualTo(result.getDamageReport().getVehicle().getLicenseNumber().getValue())
+			);
+		}
+
+		@Test
+		void 견적서를_찾을_수_없다면_예외를_반환한다() {
+			//given
+			Long noSavedDamageReportId = 200L;
+
+			//when & then
+			assertThatThrownBy(() -> estimateService.findEstimateDetailByDamageReportId(noSavedDamageReportId))
 				.isInstanceOf(NotFoundException.class);
 		}
 	}

--- a/src/test/java/com/carumuch/capstone/estimate/integration/EstimateIntegrationTest.java
+++ b/src/test/java/com/carumuch/capstone/estimate/integration/EstimateIntegrationTest.java
@@ -1,0 +1,147 @@
+package com.carumuch.capstone.estimate.integration;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.carumuch.capstone.common.exception.NotFoundException;
+import com.carumuch.capstone.damage.domain.report.DamageReport;
+import com.carumuch.capstone.damage.domain.report.DamageReportRepository;
+import com.carumuch.capstone.damage.domain.vehicle.Vehicle;
+import com.carumuch.capstone.damage.domain.vehicle.VehicleRepository;
+import com.carumuch.capstone.estimate.application.EstimateService;
+import com.carumuch.capstone.estimate.domain.Estimate;
+import com.carumuch.capstone.estimate.domain.EstimateRepository;
+import com.carumuch.capstone.estimate.presentation.dto.response.EstimateDetailResponse;
+import com.carumuch.capstone.identity.domain.user.User;
+import com.carumuch.capstone.identity.domain.user.UserRepository;
+import com.carumuch.capstone.support.IntegrationSupportTest;
+import com.carumuch.capstone.support.fixture.DamageReportFixture;
+import com.carumuch.capstone.support.fixture.EstimateFixture;
+import com.carumuch.capstone.support.fixture.UserFixture;
+import com.carumuch.capstone.support.fixture.VehicleFixture;
+
+public class EstimateIntegrationTest extends IntegrationSupportTest {
+
+	@Autowired
+	EstimateService estimateService;
+
+	@Autowired
+	EstimateRepository estimateRepository;
+
+	@Autowired
+	DamageReportRepository damageReportRepository;
+
+	@Autowired
+	VehicleRepository vehicleRepository;
+
+	@Autowired
+	UserRepository userRepository;
+
+	Estimate estimate;
+	DamageReport damageReport;
+	Vehicle vehicle;
+
+	@BeforeEach
+	void setUp() {
+		User userFixture = UserFixture.USER_FIXTURE_1.create();
+		User user = userRepository.save(
+			new User(
+				userFixture.getLoginId(),
+				userFixture.getPassword(),
+				userFixture.getEmail(),
+				userFixture.getName(),
+				userFixture.getRole()
+			)
+		);
+
+		Vehicle vehicleFixture = VehicleFixture.VEHICLE_FIXTURE_1.create();
+		Vehicle vehicle = vehicleRepository.save(
+			new Vehicle(
+				vehicleFixture.getLicenseNumber().getValue(),
+				vehicleFixture.getOwnershipType(),
+				vehicleFixture.getBrand(),
+				vehicleFixture.getModelYear(),
+				vehicleFixture.getModelName(),
+				vehicleFixture.getOwnerName(),
+				user
+			)
+		);
+
+		DamageReport damageReportFixture = DamageReportFixture.DAMAGE_REPORT_FIXTURE_1.create();
+		DamageReport damageReport = damageReportRepository.save(
+			new DamageReport(
+				damageReportFixture.getDescription(),
+				damageReportFixture.getPreferredRepairRegion(),
+				damageReportFixture.isPickupRequired(),
+				damageReportFixture.getImagePath(),
+				vehicle
+			)
+		);
+
+		Estimate estimateFixture = EstimateFixture.ESTIMATE_FIXTURE_1.create();
+		estimate = estimateRepository.save(
+			new Estimate(
+				estimateFixture.getRepairCost(),
+				estimateFixture.getRepairParts(),
+				estimateFixture.getEstimateStatus(),
+				estimateFixture.getImagePath(),
+				damageReport
+			)
+		);
+	}
+
+	@Nested
+	@DisplayName("견적서 상세 조회 기능")
+	class FindEstimateDetail {
+		@Test
+		void 견적서_상세_정보를_조회한다() {
+		    //given
+			Long estimateId = estimate.getId();
+
+		    //when
+			EstimateDetailResponse estimateDetail = estimateService.findEstimateDetail(estimateId);
+
+			//then
+			Estimate result = estimateRepository.findDetailById(estimateId)
+				.orElseThrow(() -> new AssertionError("estimate not found"));
+
+			assertAll(
+				() -> assertThat(estimateDetail.estimateId()).isEqualTo(result.getId()),
+				() -> assertThat(estimateDetail.estimateStatus()).isEqualTo(result.getEstimateStatus().name()),
+				() -> assertThat(estimateDetail.estimateId()).isEqualTo(result.getId()),
+				() -> assertThat(estimateDetail.repairCost()).isEqualTo(result.getRepairCost()),
+				() -> assertThat(estimateDetail.repairParts().size()).isEqualTo(result.getRepairParts().size())
+			);
+			assertAll(
+				() -> assertThat(estimateDetail.damageReportInfo().isPickupRequired()).isEqualTo(result.getDamageReport().isPickupRequired()),
+				() -> assertThat(estimateDetail.damageReportInfo().preferredRepairSido()).isEqualTo(result.getDamageReport().getPreferredRepairRegion().getSido()),
+				() -> assertThat(estimateDetail.damageReportInfo().preferredRepairSigungu()).isEqualTo(result.getDamageReport().getPreferredRepairRegion().getSigungu()),
+				() -> assertThat(estimateDetail.damageReportInfo().description()).isEqualTo(result.getDamageReport().getDescription())
+			);
+			assertAll(
+				() -> assertThat(estimateDetail.vehicleInfo().brand()).isEqualTo(result.getDamageReport().getVehicle().getBrand()),
+				() -> assertThat(estimateDetail.vehicleInfo().ownershipType()).isEqualTo(result.getDamageReport().getVehicle().getOwnershipType().name()),
+				() -> assertThat(estimateDetail.vehicleInfo().ownerName()).isEqualTo(result.getDamageReport().getVehicle().getOwnerName()),
+				() -> assertThat(estimateDetail.vehicleInfo().modelName()).isEqualTo(result.getDamageReport().getVehicle().getModelName()),
+				() -> assertThat(estimateDetail.vehicleInfo().modelYear()).isEqualTo(result.getDamageReport().getVehicle().getModelYear()),
+				() -> assertThat(estimateDetail.vehicleInfo().licenseNumber()).isEqualTo(result.getDamageReport().getVehicle().getLicenseNumber().getValue())
+			);
+		}
+
+		@Test
+		void 견적서를_찾을_수_없다면_예외를_반환한다() {
+		    //given
+			Long noSavedEstimateId = 300L;
+
+		    //when & then
+			assertThatThrownBy(() -> estimateService.findEstimateDetail(noSavedEstimateId))
+				.isInstanceOf(NotFoundException.class);
+		}
+	}
+}

--- a/src/test/java/com/carumuch/capstone/estimate/integration/EstimateIntegrationTest.java
+++ b/src/test/java/com/carumuch/capstone/estimate/integration/EstimateIntegrationTest.java
@@ -253,7 +253,7 @@ public class EstimateIntegrationTest extends IntegrationSupportTest {
 		}
 
 		@Test
-		void 자신의_견적서가_이니라면_수정할_수_없다() {
+		void 자신의_견적서가_아니라면_수정할_수_없다() {
 			//given
 			Long anotherUserId = 20L;
 

--- a/src/test/java/com/carumuch/capstone/estimate/integration/EstimateIntegrationTest.java
+++ b/src/test/java/com/carumuch/capstone/estimate/integration/EstimateIntegrationTest.java
@@ -52,11 +52,12 @@ public class EstimateIntegrationTest extends IntegrationSupportTest {
 	Estimate estimate;
 	DamageReport damageReport;
 	Vehicle vehicle;
+	User user;
 
 	@BeforeEach
 	void setUp() {
 		User userFixture = UserFixture.USER_FIXTURE_1.create();
-		User user = userRepository.save(
+		user = userRepository.save(
 			new User(
 				userFixture.getLoginId(),
 				userFixture.getPassword(),
@@ -86,7 +87,8 @@ public class EstimateIntegrationTest extends IntegrationSupportTest {
 				damageReportFixture.getPreferredRepairRegion(),
 				damageReportFixture.isPickupRequired(),
 				damageReportFixture.getImagePath(),
-				vehicle
+				vehicle,
+				user.getId()
 			)
 		);
 
@@ -263,7 +265,8 @@ public class EstimateIntegrationTest extends IntegrationSupportTest {
 					damageReportFixture.getPreferredRepairRegion(),
 					damageReportFixture.isPickupRequired(),
 					damageReportFixture.getImagePath(),
-					vehicle
+					vehicle,
+					user.getId()
 				)
 			);
 

--- a/src/test/java/com/carumuch/capstone/estimate/integration/EstimateIntegrationTest.java
+++ b/src/test/java/com/carumuch/capstone/estimate/integration/EstimateIntegrationTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import com.carumuch.capstone.common.exception.CustomException;
 import com.carumuch.capstone.common.exception.NotFoundException;
 import com.carumuch.capstone.damage.domain.report.DamageReport;
 import com.carumuch.capstone.damage.domain.report.DamageReportRepository;
@@ -17,6 +18,7 @@ import com.carumuch.capstone.damage.domain.vehicle.VehicleRepository;
 import com.carumuch.capstone.estimate.application.EstimateService;
 import com.carumuch.capstone.estimate.domain.Estimate;
 import com.carumuch.capstone.estimate.domain.EstimateRepository;
+import com.carumuch.capstone.estimate.domain.EstimateStatus;
 import com.carumuch.capstone.estimate.presentation.dto.response.EstimateDetailResponse;
 import com.carumuch.capstone.identity.domain.user.User;
 import com.carumuch.capstone.identity.domain.user.UserRepository;
@@ -191,6 +193,56 @@ public class EstimateIntegrationTest extends IntegrationSupportTest {
 			//when & then
 			assertThatThrownBy(() -> estimateService.findEstimateDetailByDamageReportId(noSavedDamageReportId))
 				.isInstanceOf(NotFoundException.class);
+		}
+	}
+
+	@Nested
+	@DisplayName("견적서 상태 업데이트 기능")
+	class UpdateEstimateStatus {
+		@Test
+		void 견적서_상태를_업데이트_한다() {
+		    //given
+			Long estimateId = estimate.getId();
+			String estimateStatus = EstimateStatus.PRIVATE.name();
+
+			//when
+			estimateService.changeStatus(estimateId, estimateStatus);
+
+		    //then
+			Estimate result = estimateRepository.findById(estimateId)
+				.orElseThrow(() -> new AssertionError("estimate not found"));
+			assertThat(result.getEstimateStatus()).isEqualTo(EstimateStatus.from(estimateStatus));
+		}
+
+		@Test
+		void 견적서를_찾지_못하면_예외를_반환한다() {
+			//given
+			Long noSavedDamageReportId = 200L;
+
+			//when & then
+			assertThatThrownBy(() -> estimateService.findEstimateDetailByDamageReportId(noSavedDamageReportId))
+				.isInstanceOf(NotFoundException.class);
+		}
+
+		@Test
+		void 올바른_견적서_상태가_아니라면_예외를_반환한다() {
+		    //given
+			Long estimateId = estimate.getId();
+			String estimateStatus = "WRONG_STATUS";
+
+		    //when & then
+			assertThatThrownBy(() -> estimateService.changeStatus(estimateId, estimateStatus))
+				.isInstanceOf(CustomException.class);
+		}
+
+		@Test
+		void 이미_매칭된_견적서의_상태를_변경하면_예외를_반환한다() {
+		    //given
+			Estimate closedEstimate = estimateRepository.save(EstimateFixture.ESTIMATE_FIXTURE_2.create());
+
+			//when & then
+			assertThatThrownBy(() -> estimateService.changeStatus(closedEstimate.getId(), EstimateStatus.PRIVATE.name()))
+				.isInstanceOf(CustomException.class);
 		}
 	}
 }

--- a/src/test/java/com/carumuch/capstone/estimate/integration/EstimateIntegrationTest.java
+++ b/src/test/java/com/carumuch/capstone/estimate/integration/EstimateIntegrationTest.java
@@ -221,10 +221,10 @@ public class EstimateIntegrationTest extends IntegrationSupportTest {
 		@Test
 		void 견적서를_찾지_못하면_예외를_반환한다() {
 			//given
-			Long noSavedDamageReportId = 200L;
+			Long estimateId = 300L;
 
 			//when & then
-			assertThatThrownBy(() -> estimateService.findEstimateDetailByDamageReportId(noSavedDamageReportId))
+			assertThatThrownBy(() -> estimateService.changeStatus(estimateId, EstimateStatus.PRIVATE.name()))
 				.isInstanceOf(NotFoundException.class);
 		}
 

--- a/src/test/java/com/carumuch/capstone/estimate/integration/EstimateIntegrationTest.java
+++ b/src/test/java/com/carumuch/capstone/estimate/integration/EstimateIntegrationTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import com.carumuch.capstone.common.exception.CustomException;
+import com.carumuch.capstone.common.exception.ForbiddenException;
 import com.carumuch.capstone.common.exception.NotFoundException;
 import com.carumuch.capstone.common.presentation.dto.PagingRequest;
 import com.carumuch.capstone.common.presentation.dto.PagingResponse;
@@ -212,7 +213,7 @@ public class EstimateIntegrationTest extends IntegrationSupportTest {
 			String estimateStatus = EstimateStatus.PRIVATE.name();
 
 			//when
-			estimateService.changeStatus(estimateId, estimateStatus);
+			estimateService.changeStatus(estimateId, estimateStatus, user.getId());
 
 		    //then
 			Estimate result = estimateRepository.findById(estimateId)
@@ -226,7 +227,7 @@ public class EstimateIntegrationTest extends IntegrationSupportTest {
 			Long estimateId = 300L;
 
 			//when & then
-			assertThatThrownBy(() -> estimateService.changeStatus(estimateId, EstimateStatus.PRIVATE.name()))
+			assertThatThrownBy(() -> estimateService.changeStatus(estimateId, EstimateStatus.PRIVATE.name(), user.getId()))
 				.isInstanceOf(NotFoundException.class);
 		}
 
@@ -237,7 +238,7 @@ public class EstimateIntegrationTest extends IntegrationSupportTest {
 			String estimateStatus = "WRONG_STATUS";
 
 		    //when & then
-			assertThatThrownBy(() -> estimateService.changeStatus(estimateId, estimateStatus))
+			assertThatThrownBy(() -> estimateService.changeStatus(estimateId, estimateStatus, user.getId()))
 				.isInstanceOf(CustomException.class);
 		}
 
@@ -247,8 +248,18 @@ public class EstimateIntegrationTest extends IntegrationSupportTest {
 			Estimate closedEstimate = estimateRepository.save(EstimateFixture.ESTIMATE_FIXTURE_2.create());
 
 			//when & then
-			assertThatThrownBy(() -> estimateService.changeStatus(closedEstimate.getId(), EstimateStatus.PRIVATE.name()))
+			assertThatThrownBy(() -> estimateService.changeStatus(closedEstimate.getId(), EstimateStatus.PRIVATE.name(), user.getId()))
 				.isInstanceOf(CustomException.class);
+		}
+
+		@Test
+		void 자신의_견적서가_이니라면_수정할_수_없다() {
+			//given
+			Long anotherUserId = 20L;
+
+			//when & then
+			assertThatThrownBy(() -> estimateService.changeStatus(estimate.getId(), EstimateStatus.PRIVATE.name(), anotherUserId))
+				.isInstanceOf(ForbiddenException.class);
 		}
 	}
 

--- a/src/test/java/com/carumuch/capstone/estimate/presentation/EstimateControllerTest.java
+++ b/src/test/java/com/carumuch/capstone/estimate/presentation/EstimateControllerTest.java
@@ -1,17 +1,20 @@
 package com.carumuch.capstone.estimate.presentation;
 
+import static com.epages.restdocs.apispec.ResourceDocumentation.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
@@ -22,8 +25,12 @@ import com.carumuch.capstone.common.exception.CustomException;
 import com.carumuch.capstone.common.exception.NotFoundException;
 import com.carumuch.capstone.common.presentation.dto.ApiErrorResponse;
 import com.carumuch.capstone.common.presentation.dto.ApiResponse;
+import com.carumuch.capstone.common.presentation.dto.PagingRequest;
+import com.carumuch.capstone.common.presentation.dto.PagingResponse;
+import com.carumuch.capstone.estimate.application.dto.EstimateSearchCondition;
 import com.carumuch.capstone.estimate.domain.Estimate;
 import com.carumuch.capstone.estimate.domain.EstimateStatus;
+import com.carumuch.capstone.estimate.presentation.dto.request.SearchEstimateRequest;
 import com.carumuch.capstone.estimate.presentation.dto.request.UpdateEstimateStatusRequest;
 import com.carumuch.capstone.estimate.presentation.dto.response.EstimateDetailResponse;
 import com.carumuch.capstone.support.RestDocsSupport;
@@ -404,6 +411,167 @@ class EstimateControllerTest extends RestDocsSupport {
 							.build())
 					)
 				);
+		}
+	}
+	
+	@Nested
+	@DisplayName("견적서 조건 검색 API 테스트")
+	class SearchEstimates {
+		@Test
+		void 견적서_조건_검색_기능_2XX() throws Exception {
+			//given
+			SearchEstimateRequest searchEstimateRequest = new SearchEstimateRequest(
+				null, null, null, null, null, null, null, null
+			);
+			PagingRequest pagingRequest = new PagingRequest(null, null, null);
+
+			Estimate estimateFixture = EstimateFixture.ESTIMATE_FIXTURE_1.create();
+			ReflectionTestUtils.setField(estimateFixture, "id", 404L);
+			ReflectionTestUtils.setField(estimateFixture, "createDate", LocalDateTime.now());
+
+			Estimate estimateFixture2 = EstimateFixture.ESTIMATE_FIXTURE_4.create();
+			ReflectionTestUtils.setField(estimateFixture2, "id", 500L);
+			ReflectionTestUtils.setField(estimateFixture2, "createDate", LocalDateTime.now());
+
+
+			PagingResponse<EstimateDetailResponse> responseDto = PagingResponse.from(
+				new PageImpl<>(List.of(estimateFixture, estimateFixture2)).map(EstimateDetailResponse::new));
+
+			Mockito.when(estimateService.searchEstimates(searchEstimateRequest, pagingRequest))
+				.thenReturn(responseDto);
+
+			//when
+			ResultActions actions = mockMvc.perform(
+				get(BASE_URI + "/search")
+			);
+
+			//then
+			actions
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.message").value(BASE_SUCCESS_MESSAGE))
+
+				// paging meta
+				.andExpect(jsonPath("$.data.page.number").value(1))
+
+				// content[0] = 견적서 정보
+				.andExpect(jsonPath("$.data.content[0].estimateId").value(responseDto.content().get(0).estimateId()))
+				.andExpect(jsonPath("$.data.content[0].repairCost").value(responseDto.content().get(0).repairCost()))
+				.andExpect(jsonPath("$.data.content[0].repairParts").isArray())
+				.andExpect(
+					jsonPath("$.data.content[0].estimateStatus").value(responseDto.content().get(0).estimateStatus()))
+				.andExpect(jsonPath("$.data.content[0].imagePath").value(responseDto.content().get(0).imagePath()))
+
+				// 사고 레포트 정보
+				.andExpect(jsonPath("$.data.content[0].damageReportInfo.description")
+					.value(responseDto.content().get(0).damageReportInfo().description()))
+				.andExpect(jsonPath("$.data.content[0].damageReportInfo.preferredRepairSido")
+					.value(responseDto.content().get(0).damageReportInfo().preferredRepairSido()))
+				.andExpect(jsonPath("$.data.content[0].damageReportInfo.preferredRepairSigungu")
+					.value(responseDto.content().get(0).damageReportInfo().preferredRepairSigungu()))
+				.andExpect(jsonPath("$.data.content[0].damageReportInfo.isPickupRequired")
+					.value(responseDto.content().get(0).damageReportInfo().isPickupRequired()))
+
+				// 차량 정보
+				.andExpect(jsonPath("$.data.content[0].vehicleInfo.brand")
+					.value(responseDto.content().get(0).vehicleInfo().brand()))
+				.andExpect(jsonPath("$.data.content[0].vehicleInfo.licenseNumber")
+					.value(responseDto.content().get(0).vehicleInfo().licenseNumber()))
+				.andExpect(jsonPath("$.data.content[0].vehicleInfo.modelName")
+					.value(responseDto.content().get(0).vehicleInfo().modelName()))
+				.andExpect(jsonPath("$.data.content[0].vehicleInfo.modelYear")
+					.value(responseDto.content().get(0).vehicleInfo().modelYear()))
+				.andExpect(jsonPath("$.data.content[0].vehicleInfo.ownerName")
+					.value(responseDto.content().get(0).vehicleInfo().ownerName()))
+				.andExpect(jsonPath("$.data.content[0].vehicleInfo.ownershipType")
+					.value(responseDto.content().get(0).vehicleInfo().ownershipType()))
+				.andDo(restDocsHandler.document(
+					ResourceDocumentation.resource(ResourceSnippetParameters.builder()
+						.tag(BASE_TAG)
+						.summary("견적서 조건 검색")
+						.description("## 견적서 조건 검색 기능 \n"
+							+ "### 설명 \n"
+							+ "- 원하는 조건을 쿼리파라미터에 추가해주세요 (ex: ?brand=기아)"
+						)
+						.queryParameters(
+							parameterWithName("size").description(
+								"페이지에 표시할 size입니다. 10 ~ 100입니다. 만약 다른 값이 들어오면 10개로 고정합니다.").optional(),
+							parameterWithName("page").description("page가 없거나, 음수라면 첫 페이지로 고정합니다.").optional(),
+							parameterWithName("size").description("'POPULOR' or 'populor'시 공업사 수리 희망 수가 높은 순으로 제공합니다.(기본: 생성일 기준 내림차순)").optional(),
+							parameterWithName("minRepairCost").description("최소 산정 금액").optional(),
+							parameterWithName("maxRepairCost").description("최대 산정 금액").optional(),
+							parameterWithName("sido").description("수리 희망 시/도").optional(),
+							parameterWithName("sigungu").description("수리 희망 시/군/구").optional(),
+							parameterWithName("isPickupRequired").description("수리 시 픽업 희망 유무").optional(),
+							parameterWithName("brand").description("사고 차량의 브랜드").optional(),
+							parameterWithName("modelYear").description("사고 차량의 연식").optional(),
+							parameterWithName("modelName").description("사고 차량의 이름").optional()
+						)
+						.responseSchema(Schema.schema(PagingResponse.class.getSimpleName()))
+						.responseFields(
+							fieldWithPath("message").description("성공 응답 메세지입니다.").type(JsonFieldType.STRING),
+
+							// paging wrapper
+							fieldWithPath("data.content").description("페이징된 견적서 목록입니다.").type(JsonFieldType.ARRAY),
+							fieldWithPath("data.page").description("페이지 메타데이터입니다.").type(JsonFieldType.OBJECT),
+
+							// page meta
+							fieldWithPath("data.page.number").description("현재 페이지 번호(1부터 시작)입니다.")
+								.type(JsonFieldType.NUMBER),
+							fieldWithPath("data.page.size").description("페이지 크기입니다.").type(JsonFieldType.NUMBER),
+							fieldWithPath("data.page.totalElements").description("전체 요소 개수입니다.")
+								.type(JsonFieldType.NUMBER),
+							fieldWithPath("data.page.totalPages").description("전체 페이지 수입니다.")
+								.type(JsonFieldType.NUMBER),
+							fieldWithPath("data.page.hasNext").description("다음 페이지 존재 여부입니다.")
+								.type(JsonFieldType.BOOLEAN),
+							fieldWithPath("data.page.hasPrevious").description("이전 페이지 존재 여부입니다.")
+								.type(JsonFieldType.BOOLEAN),
+
+							// content
+							fieldWithPath("data.content[].estimateId").description("견적서 식별자입니다.")
+								.type(JsonFieldType.NUMBER),
+							fieldWithPath("data.content[].repairCost").description("사고 견적 분석 금액입니다.")
+								.type(JsonFieldType.NUMBER),
+							fieldWithPath("data.content[].repairParts").description("사고 수리 예상 부위입니다.")
+								.type(JsonFieldType.ARRAY),
+							fieldWithPath("data.content[].estimateStatus").description("견적서의 상태입니다.")
+								.type(JsonFieldType.STRING),
+							fieldWithPath("data.content[].imagePath").description("견적서의 사고 분석 사진 주소입니다.")
+								.type(JsonFieldType.STRING),
+							fieldWithPath("data.content[].createdAt").description("견적서 생성일 입니다.")
+								.type(JsonFieldType.STRING),
+
+							// 사고 레포트 정보
+							fieldWithPath("data.content[].damageReportInfo").description("사고 레포트 정보입니다.")
+								.type(JsonFieldType.OBJECT),
+							fieldWithPath("data.content[].damageReportInfo.description").description(
+								"사용자가 기술한 사고 레포트의 내용입니다.").type(JsonFieldType.STRING),
+							fieldWithPath("data.content[].damageReportInfo.preferredRepairSido").description(
+								"수리 희망 시/도 입니다.").type(JsonFieldType.STRING),
+							fieldWithPath("data.content[].damageReportInfo.preferredRepairSigungu").description(
+								"수리 희망 시/군/구 입니다.").type(JsonFieldType.STRING),
+							fieldWithPath("data.content[].damageReportInfo.isPickupRequired").description(
+								"사고 수리 픽업 희망 유무입니다.").type(JsonFieldType.BOOLEAN),
+
+							// 차량 정보
+							fieldWithPath("data.content[].vehicleInfo").description("사고 차량 정보입니다.")
+								.type(JsonFieldType.OBJECT),
+							fieldWithPath("data.content[].vehicleInfo.brand").description("사고 차량의 브랜드입니다.")
+								.type(JsonFieldType.STRING),
+							fieldWithPath("data.content[].vehicleInfo.licenseNumber").description("차량의 번호입니다.")
+								.type(JsonFieldType.STRING),
+							fieldWithPath("data.content[].vehicleInfo.modelName").description("사고 차량의 모델명입니다.")
+								.type(JsonFieldType.STRING),
+							fieldWithPath("data.content[].vehicleInfo.modelYear").description("사고 차량의 연식입니다.")
+								.type(JsonFieldType.NUMBER),
+							fieldWithPath("data.content[].vehicleInfo.ownerName").description("사고 차량의 실소유자명입니다.")
+								.type(JsonFieldType.STRING),
+							fieldWithPath("data.content[].vehicleInfo.ownershipType").description("차량의 유형입니다.")
+								.type(JsonFieldType.STRING)
+						)
+						.build()
+					)
+				));
 		}
 	}
 }

--- a/src/test/java/com/carumuch/capstone/estimate/presentation/EstimateControllerTest.java
+++ b/src/test/java/com/carumuch/capstone/estimate/presentation/EstimateControllerTest.java
@@ -33,8 +33,10 @@ import com.carumuch.capstone.estimate.domain.EstimateStatus;
 import com.carumuch.capstone.estimate.presentation.dto.request.SearchEstimateRequest;
 import com.carumuch.capstone.estimate.presentation.dto.request.UpdateEstimateStatusRequest;
 import com.carumuch.capstone.estimate.presentation.dto.response.EstimateDetailResponse;
+import com.carumuch.capstone.identity.domain.user.User;
 import com.carumuch.capstone.support.RestDocsSupport;
 import com.carumuch.capstone.support.fixture.EstimateFixture;
+import com.carumuch.capstone.support.fixture.UserFixture;
 import com.epages.restdocs.apispec.ResourceDocumentation;
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import com.epages.restdocs.apispec.Schema;
@@ -284,10 +286,11 @@ class EstimateControllerTest extends RestDocsSupport {
 		void 견적서_상태_변경_기능_2XX() throws Exception {
 		    //given
 			Long estimateId = 300L;
+
 			String changeEstimateStatus = EstimateStatus.PRIVATE.name();
 			UpdateEstimateStatusRequest requestDto = new UpdateEstimateStatusRequest(changeEstimateStatus);
 
-			Mockito.doNothing().when(estimateService).changeStatus(estimateId, changeEstimateStatus);
+			Mockito.doNothing().when(estimateService).changeStatus(Mockito.anyLong(), Mockito.anyString(), Mockito.anyLong());
 		    
 		    //when
 			ResultActions actions = mockMvc.perform(
@@ -328,8 +331,9 @@ class EstimateControllerTest extends RestDocsSupport {
 			Long estimateId = 300L;
 			String changeEstimateStatus = EstimateStatus.PRIVATE.name();
 			UpdateEstimateStatusRequest requestDto = new UpdateEstimateStatusRequest(changeEstimateStatus);
+
 			Mockito.doThrow(new NotFoundException(Estimate.class))
-				.when(estimateService).changeStatus(estimateId, changeEstimateStatus);
+				.when(estimateService).changeStatus(Mockito.anyLong(), Mockito.anyString(), Mockito.anyLong());
 
 			//when
 			ResultActions actions = mockMvc.perform(
@@ -359,8 +363,9 @@ class EstimateControllerTest extends RestDocsSupport {
 			Long estimateId = 300L;
 			String changeEstimateStatus = EstimateStatus.OPEN.name();
 			UpdateEstimateStatusRequest requestDto = new UpdateEstimateStatusRequest(changeEstimateStatus);
+
 			Mockito.doThrow(new CustomException(HttpStatus.BAD_REQUEST, errorMessage))
-				.when(estimateService).changeStatus(estimateId, changeEstimateStatus);
+				.when(estimateService).changeStatus(Mockito.anyLong(), Mockito.anyString(), Mockito.anyLong());
 
 			//when
 			ResultActions actions = mockMvc.perform(
@@ -390,8 +395,9 @@ class EstimateControllerTest extends RestDocsSupport {
 			Long estimateId = 300L;
 			String changeEstimateStatus = EstimateStatus.OPEN.name();
 			UpdateEstimateStatusRequest requestDto = new UpdateEstimateStatusRequest(changeEstimateStatus);
+
 			Mockito.doThrow(new CustomException(HttpStatus.BAD_REQUEST, errorMessage))
-				.when(estimateService).changeStatus(estimateId, changeEstimateStatus);
+				.when(estimateService).changeStatus(Mockito.anyLong(), Mockito.anyString(), Mockito.anyLong());
 
 			//when
 			ResultActions actions = mockMvc.perform(

--- a/src/test/java/com/carumuch/capstone/estimate/presentation/EstimateControllerTest.java
+++ b/src/test/java/com/carumuch/capstone/estimate/presentation/EstimateControllerTest.java
@@ -393,7 +393,7 @@ class EstimateControllerTest extends RestDocsSupport {
 			String errorMessage = "올바른 견적서 상태가 아닙니다.";
 
 			Long estimateId = 300L;
-			String changeEstimateStatus = EstimateStatus.OPEN.name();
+			String changeEstimateStatus = "wrongStatus";
 			UpdateEstimateStatusRequest requestDto = new UpdateEstimateStatusRequest(changeEstimateStatus);
 
 			Mockito.doThrow(new CustomException(HttpStatus.BAD_REQUEST, errorMessage))

--- a/src/test/java/com/carumuch/capstone/estimate/presentation/EstimateControllerTest.java
+++ b/src/test/java/com/carumuch/capstone/estimate/presentation/EstimateControllerTest.java
@@ -496,7 +496,7 @@ class EstimateControllerTest extends RestDocsSupport {
 							parameterWithName("size").description(
 								"페이지에 표시할 size입니다. 10 ~ 100입니다. 만약 다른 값이 들어오면 10개로 고정합니다.").optional(),
 							parameterWithName("page").description("page가 없거나, 음수라면 첫 페이지로 고정합니다.").optional(),
-							parameterWithName("size").description("'POPULOR' or 'populor'시 공업사 수리 희망 수가 높은 순으로 제공합니다.(기본: 생성일 기준 내림차순)").optional(),
+							parameterWithName("sort").description("'POPULAR' or 'popular' 시 공업사 수리 희망 수가 높은 순으로 제공합니다.(기본: 생성일 기준 내림차순)").optional(),
 							parameterWithName("minRepairCost").description("최소 산정 금액").optional(),
 							parameterWithName("maxRepairCost").description("최대 산정 금액").optional(),
 							parameterWithName("sido").description("수리 희망 시/도").optional(),

--- a/src/test/java/com/carumuch/capstone/estimate/presentation/EstimateControllerTest.java
+++ b/src/test/java/com/carumuch/capstone/estimate/presentation/EstimateControllerTest.java
@@ -12,14 +12,20 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.ResultActions;
 
+import com.carumuch.capstone.common.exception.CustomException;
 import com.carumuch.capstone.common.exception.NotFoundException;
 import com.carumuch.capstone.common.presentation.dto.ApiErrorResponse;
+import com.carumuch.capstone.common.presentation.dto.ApiResponse;
 import com.carumuch.capstone.damage.presentation.dto.response.vehicle.VehicleInfoResponse;
 import com.carumuch.capstone.estimate.domain.Estimate;
+import com.carumuch.capstone.estimate.domain.EstimateStatus;
+import com.carumuch.capstone.estimate.presentation.dto.request.UpdateEstimateStatusRequest;
 import com.carumuch.capstone.estimate.presentation.dto.response.EstimateDetailResponse;
 import com.carumuch.capstone.support.RestDocsSupport;
 import com.carumuch.capstone.support.fixture.EstimateFixture;
@@ -36,7 +42,7 @@ class EstimateControllerTest extends RestDocsSupport {
 	private static final String BASE_TAG = "Estimate";
 
 	@Nested
-	@DisplayName("견적서 상세 조회 기능")
+	@DisplayName("견적서 상세 조회 API 테스트")
 	class FindEstimateDetail {
 		@Test
 		void 견적서_상세_조회_2XX() throws Exception {
@@ -139,6 +145,143 @@ class EstimateControllerTest extends RestDocsSupport {
 			actions
 				.andExpect(status().isNotFound())
 				.andExpect(result -> Assertions.assertInstanceOf(NotFoundException.class, result.getResolvedException()))
+				.andExpect(jsonPath("$.message").value(errorMessage))
+				.andDo(restDocsHandler.document(
+						ResourceDocumentation.resource(ResourceSnippetParameters.builder()
+							.tag(BASE_TAG)
+							.responseSchema(Schema.schema(ApiErrorResponse.class.getSimpleName()))
+							.build())
+					)
+				);
+		}
+	}
+	
+	@Nested
+	@DisplayName("견적서 상태 변경 API 테스트")
+	class UpdateEstimateStatus {
+		@Test
+		void 견적서_상태_변경_기능_2XX() throws Exception {
+		    //given
+			Long estimateId = 300L;
+			String changeEstimateStatus = EstimateStatus.PRIVATE.name();
+			UpdateEstimateStatusRequest requestDto = new UpdateEstimateStatusRequest(changeEstimateStatus);
+
+			Mockito.doNothing().when(estimateService).changeStatus(estimateId, changeEstimateStatus);
+		    
+		    //when
+			ResultActions actions = mockMvc.perform(
+				put(BASE_URI + "/{estimateId}/status", estimateId)
+					.content(objectMapper.writeValueAsString(requestDto))
+					.contentType(MediaType.APPLICATION_JSON));
+
+			//then
+			actions
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.message").value(BASE_SUCCESS_MESSAGE))
+				.andExpect(jsonPath("$.data").isEmpty())
+				.andDo(restDocsHandler.document(
+						ResourceDocumentation.resource(ResourceSnippetParameters.builder()
+							.tag(BASE_TAG)
+							.summary("견적서 상태 변경")
+							.description("## 견적서 상태 변경 기능 \n"
+								+ "### 사용법 \n"
+								+ "- PRIVATE, OPEN 중 선택하여, 작성해주세요. \n"
+								+ "- 대문자, 소문자 모두 수용합니다."
+								+ "- 이미 매칭된 견적서는 상태를 수정할 수 없습니다."
+							)
+							.requestSchema(Schema.schema(UpdateEstimateStatusRequest.class.getSimpleName()))
+							.requestFields(
+								fieldWithPath("status").description("변경할 견적서의 상태입니다. (PRIVATE, OPEN 중에 선택해야합니다.)").type(JsonFieldType.STRING)
+							)
+							.responseSchema(Schema.schema(ApiResponse.class.getSimpleName()))
+							.build())
+					)
+				);
+		}
+
+		@Test
+		void 견적서_상태_변경_기능_4XX_견적서를_찾을_수_없는_경우() throws Exception {
+			//given
+			String errorMessage = Estimate.class.getSimpleName() + "을(를) 찾을 수 없습니다.";
+
+			Long estimateId = 300L;
+			String changeEstimateStatus = EstimateStatus.PRIVATE.name();
+			UpdateEstimateStatusRequest requestDto = new UpdateEstimateStatusRequest(changeEstimateStatus);
+			Mockito.doThrow(new NotFoundException(Estimate.class))
+				.when(estimateService).changeStatus(estimateId, changeEstimateStatus);
+
+			//when
+			ResultActions actions = mockMvc.perform(
+				put(BASE_URI + "/{estimateId}/status", estimateId)
+					.content(objectMapper.writeValueAsString(requestDto))
+					.contentType(MediaType.APPLICATION_JSON));
+
+			//then
+			actions
+				.andExpect(status().isNotFound())
+				.andExpect(result -> Assertions.assertInstanceOf(NotFoundException.class, result.getResolvedException()))
+				.andExpect(jsonPath("$.message").value(errorMessage))
+				.andDo(restDocsHandler.document(
+						ResourceDocumentation.resource(ResourceSnippetParameters.builder()
+							.tag(BASE_TAG)
+							.responseSchema(Schema.schema(ApiErrorResponse.class.getSimpleName()))
+							.build())
+					)
+				);
+		}
+
+		@Test
+		void 견적서_상태_변경_기능_4XX_이미_매칭_완료된_견적서인_경우() throws Exception {
+			//given
+			String errorMessage = "이미 매칭된 견적서 입니다.";
+
+			Long estimateId = 300L;
+			String changeEstimateStatus = EstimateStatus.OPEN.name();
+			UpdateEstimateStatusRequest requestDto = new UpdateEstimateStatusRequest(changeEstimateStatus);
+			Mockito.doThrow(new CustomException(HttpStatus.BAD_REQUEST, errorMessage))
+				.when(estimateService).changeStatus(estimateId, changeEstimateStatus);
+
+			//when
+			ResultActions actions = mockMvc.perform(
+				put(BASE_URI + "/{estimateId}/status", estimateId)
+					.content(objectMapper.writeValueAsString(requestDto))
+					.contentType(MediaType.APPLICATION_JSON));
+
+			//then
+			actions
+				.andExpect(status().isBadRequest())
+				.andExpect(result -> Assertions.assertInstanceOf(CustomException.class, result.getResolvedException()))
+				.andExpect(jsonPath("$.message").value(errorMessage))
+				.andDo(restDocsHandler.document(
+						ResourceDocumentation.resource(ResourceSnippetParameters.builder()
+							.tag(BASE_TAG)
+							.responseSchema(Schema.schema(ApiErrorResponse.class.getSimpleName()))
+							.build())
+					)
+				);
+		}
+
+		@Test
+		void 견적서_상태_변경_기능_4XX_수용할_수_없는_견적서_상태인_경우() throws Exception {
+			//given
+			String errorMessage = "올바른 견적서 상태가 아닙니다.";
+
+			Long estimateId = 300L;
+			String changeEstimateStatus = EstimateStatus.OPEN.name();
+			UpdateEstimateStatusRequest requestDto = new UpdateEstimateStatusRequest(changeEstimateStatus);
+			Mockito.doThrow(new CustomException(HttpStatus.BAD_REQUEST, errorMessage))
+				.when(estimateService).changeStatus(estimateId, changeEstimateStatus);
+
+			//when
+			ResultActions actions = mockMvc.perform(
+				put(BASE_URI + "/{estimateId}/status", estimateId)
+					.content(objectMapper.writeValueAsString(requestDto))
+					.contentType(MediaType.APPLICATION_JSON));
+
+			//then
+			actions
+				.andExpect(status().isBadRequest())
+				.andExpect(result -> Assertions.assertInstanceOf(CustomException.class, result.getResolvedException()))
 				.andExpect(jsonPath("$.message").value(errorMessage))
 				.andDo(restDocsHandler.document(
 						ResourceDocumentation.resource(ResourceSnippetParameters.builder()

--- a/src/test/java/com/carumuch/capstone/estimate/presentation/EstimateControllerTest.java
+++ b/src/test/java/com/carumuch/capstone/estimate/presentation/EstimateControllerTest.java
@@ -22,7 +22,6 @@ import com.carumuch.capstone.common.exception.CustomException;
 import com.carumuch.capstone.common.exception.NotFoundException;
 import com.carumuch.capstone.common.presentation.dto.ApiErrorResponse;
 import com.carumuch.capstone.common.presentation.dto.ApiResponse;
-import com.carumuch.capstone.damage.presentation.dto.response.vehicle.VehicleInfoResponse;
 import com.carumuch.capstone.estimate.domain.Estimate;
 import com.carumuch.capstone.estimate.domain.EstimateStatus;
 import com.carumuch.capstone.estimate.presentation.dto.request.UpdateEstimateStatusRequest;
@@ -94,7 +93,7 @@ class EstimateControllerTest extends RestDocsSupport {
 								+ "### 설명 \n"
 								+ "- 사고 레포트에 의해 생성된 견적서 정보를 조회합니다.\n"
 							)
-							.responseSchema(Schema.schema(VehicleInfoResponse.class.getSimpleName()))
+							.responseSchema(Schema.schema(EstimateDetailResponse.class.getSimpleName()))
 							.responseFields(
 								fieldWithPath("message").description("성공 응답 메세지입니다.").type(JsonFieldType.STRING),
 								// 견적서 정보
@@ -133,12 +132,127 @@ class EstimateControllerTest extends RestDocsSupport {
 			Mockito.doThrow(new NotFoundException(Estimate.class))
 				.when(estimateService).findEstimateDetail(estimateId);
 
-			Estimate estimate = EstimateFixture.ESTIMATE_FIXTURE_1.create();
-			EstimateDetailResponse responseDto = new EstimateDetailResponse(estimate);
-
 			//when
 			ResultActions actions = mockMvc.perform(
 				get(BASE_URI+ "/{estimateId}", estimateId)
+			);
+
+			//then
+			actions
+				.andExpect(status().isNotFound())
+				.andExpect(result -> Assertions.assertInstanceOf(NotFoundException.class, result.getResolvedException()))
+				.andExpect(jsonPath("$.message").value(errorMessage))
+				.andDo(restDocsHandler.document(
+						ResourceDocumentation.resource(ResourceSnippetParameters.builder()
+							.tag(BASE_TAG)
+							.responseSchema(Schema.schema(ApiErrorResponse.class.getSimpleName()))
+							.build())
+					)
+				);
+		}
+	}
+
+	@Nested
+	@DisplayName("사고레포트를_통한_견적서 상세 조회 API 테스트")
+	class FindEstimateDetailByDamageReportId {
+		@Test
+		void 사고레포트를_통한_견적서_상세_조회_2XX() throws Exception {
+			//given
+			Long damageReportId = 100L;
+
+			Long estimateId = 300L;
+			Estimate estimate = EstimateFixture.ESTIMATE_FIXTURE_1.create();
+			ReflectionTestUtils.setField(estimate, "id", estimateId);
+			ReflectionTestUtils.setField(estimate, "createDate", LocalDateTime.now());
+
+			EstimateDetailResponse responseDto = new EstimateDetailResponse(estimate);
+
+			Mockito.when(estimateService.findEstimateDetailByDamageReportId(damageReportId))
+				.thenReturn(responseDto);
+
+			//when
+			ResultActions actions = mockMvc.perform(
+				get(BASE_URI)
+					.param("damageReportId", damageReportId.toString())
+			);
+
+			//then
+			actions
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.message").value(BASE_SUCCESS_MESSAGE))
+
+				// 견적서 정보
+				.andExpect(jsonPath("$.data.estimateId").value(responseDto.estimateId()))
+				.andExpect(jsonPath("$.data.repairCost").value(responseDto.repairCost()))
+				.andExpect(jsonPath("$.data.repairParts").isArray())
+				.andExpect(jsonPath("$.data.estimateStatus").value(responseDto.estimateStatus()))
+				.andExpect(jsonPath("$.data.imagePath").value(responseDto.imagePath()))
+
+				// 사고 레포트 정보
+				.andExpect(jsonPath("$.data.damageReportInfo.description").value(responseDto.damageReportInfo().description()))
+				.andExpect(jsonPath("$.data.damageReportInfo.preferredRepairSido").value(responseDto.damageReportInfo().preferredRepairSido()))
+				.andExpect(jsonPath("$.data.damageReportInfo.preferredRepairSigungu").value(responseDto.damageReportInfo().preferredRepairSigungu()))
+				.andExpect(jsonPath("$.data.damageReportInfo.isPickupRequired").value(responseDto.damageReportInfo().isPickupRequired()))
+
+				// 차량 정보
+				.andExpect(jsonPath("$.data.vehicleInfo.brand").value(responseDto.vehicleInfo().brand()))
+				.andExpect(jsonPath("$.data.vehicleInfo.licenseNumber").value(responseDto.vehicleInfo().licenseNumber()))
+				.andExpect(jsonPath("$.data.vehicleInfo.modelName").value(responseDto.vehicleInfo().modelName()))
+				.andExpect(jsonPath("$.data.vehicleInfo.modelYear").value(responseDto.vehicleInfo().modelYear()))
+				.andExpect(jsonPath("$.data.vehicleInfo.ownerName").value(responseDto.vehicleInfo().ownerName()))
+				.andExpect(jsonPath("$.data.vehicleInfo.ownershipType").value(responseDto.vehicleInfo().ownershipType()))
+				.andDo(restDocsHandler.document(
+						ResourceDocumentation.resource(ResourceSnippetParameters.builder()
+							.tag(BASE_TAG)
+							.summary("사고레포트를 통한 견적서 상세 조회")
+							.description("## 사고레포트를 통한 견적서 상세 조회 기능 \n"
+								+ "### 설명 \n"
+								+ "- 사고 레포트에 의해 생성된 견적서 정보를 조회합니다.\n"
+							)
+							.responseSchema(Schema.schema(EstimateDetailResponse.class.getSimpleName()))
+							.responseFields(
+								fieldWithPath("message").description("성공 응답 메세지입니다.").type(JsonFieldType.STRING),
+								// 견적서 정보
+								fieldWithPath("data.estimateId").description("견적서 식별자입니다.").type(JsonFieldType.NUMBER),
+								fieldWithPath("data.repairCost").description("사고 견적 분석 금액입니다.").type(JsonFieldType.NUMBER),
+								fieldWithPath("data.repairParts").description("사고 수리 예상 부위입니다.").type(JsonFieldType.ARRAY),
+								fieldWithPath("data.estimateStatus").description("견적서의 상태입니다.").type(JsonFieldType.STRING),
+								fieldWithPath("data.imagePath").description("견적서의 사고 분석 사진 주소입니다.").type(JsonFieldType.STRING),
+								fieldWithPath("data.createdAt").description("견적서 생성일 입니다.").type(JsonFieldType.STRING),
+
+								// 사고 레포트 정보
+								fieldWithPath("data.damageReportInfo.description").description("사용자가 기술한 사고 레포트의 내용입니다.").type(JsonFieldType.STRING),
+								fieldWithPath("data.damageReportInfo.preferredRepairSido").description("수리 희망 시/도 입니다.").type(JsonFieldType.STRING),
+								fieldWithPath("data.damageReportInfo.preferredRepairSigungu").description("수리 희망 시/군/구 입니다.").type(JsonFieldType.STRING),
+								fieldWithPath("data.damageReportInfo.isPickupRequired").description("사고 수리 픽업 희망 유무입니다.").type(JsonFieldType.BOOLEAN),
+
+								// 차량 정보
+								fieldWithPath("data.vehicleInfo.brand").description("차량의 브랜드입니다.").type(JsonFieldType.STRING),
+								fieldWithPath("data.vehicleInfo.licenseNumber").description("차량의 번호입니다.").type(JsonFieldType.STRING),
+								fieldWithPath("data.vehicleInfo.modelName").description("차량의 모델명입니다.").type(JsonFieldType.STRING),
+								fieldWithPath("data.vehicleInfo.modelYear").description("차량의 연입니다.").type(JsonFieldType.NUMBER),
+								fieldWithPath("data.vehicleInfo.ownerName").description("차량의 실소유자명입니다.").type(JsonFieldType.STRING),
+								fieldWithPath("data.vehicleInfo.ownershipType").description("차량의 유형입니다.").type(JsonFieldType.STRING)
+							)
+							.build()
+						)
+					)
+				);
+		}
+
+		@Test
+		void 사고레포트를_통한_견적서_상세_조회_4XX_견적서를_찾지_못한_경우() throws Exception {
+			String errorMessage = Estimate.class.getSimpleName() + "을(를) 찾을 수 없습니다.";
+
+			Long damageReportId = 100L;
+
+			Mockito.doThrow(new NotFoundException(Estimate.class))
+				.when(estimateService).findEstimateDetailByDamageReportId(damageReportId);
+
+			//when
+			ResultActions actions = mockMvc.perform(
+				get(BASE_URI)
+					.param("damageReportId", damageReportId.toString())
 			);
 
 			//then

--- a/src/test/java/com/carumuch/capstone/estimate/presentation/EstimateControllerTest.java
+++ b/src/test/java/com/carumuch/capstone/estimate/presentation/EstimateControllerTest.java
@@ -1,0 +1,152 @@
+package com.carumuch.capstone.estimate.presentation;
+
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.ResultActions;
+
+import com.carumuch.capstone.common.exception.NotFoundException;
+import com.carumuch.capstone.common.presentation.dto.ApiErrorResponse;
+import com.carumuch.capstone.damage.presentation.dto.response.vehicle.VehicleInfoResponse;
+import com.carumuch.capstone.estimate.domain.Estimate;
+import com.carumuch.capstone.estimate.presentation.dto.response.EstimateDetailResponse;
+import com.carumuch.capstone.support.RestDocsSupport;
+import com.carumuch.capstone.support.fixture.EstimateFixture;
+import com.epages.restdocs.apispec.ResourceDocumentation;
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.epages.restdocs.apispec.Schema;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+class EstimateControllerTest extends RestDocsSupport {
+
+	private static final String BASE_URI = "/estimates";
+	private static final String BASE_TAG = "Estimate";
+
+	@Nested
+	@DisplayName("견적서 상세 조회 기능")
+	class FindEstimateDetail {
+		@Test
+		void 견적서_상세_조회_2XX() throws Exception {
+			//given
+			Long estimateId = 300L;
+			Estimate estimate = EstimateFixture.ESTIMATE_FIXTURE_1.create();
+			ReflectionTestUtils.setField(estimate, "id", estimateId);
+			ReflectionTestUtils.setField(estimate, "createDate", LocalDateTime.now());
+
+			EstimateDetailResponse responseDto = new EstimateDetailResponse(estimate);
+
+			Mockito.when(estimateService.findEstimateDetail(estimateId))
+				.thenReturn(responseDto);
+
+			//when
+			ResultActions actions = mockMvc.perform(
+				get(BASE_URI + "/{estimateId}", estimateId));
+
+			//then
+			actions
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.message").value(BASE_SUCCESS_MESSAGE))
+
+				// 견적서 정보
+				.andExpect(jsonPath("$.data.estimateId").value(responseDto.estimateId()))
+				.andExpect(jsonPath("$.data.repairCost").value(responseDto.repairCost()))
+				.andExpect(jsonPath("$.data.repairParts").isArray())
+				.andExpect(jsonPath("$.data.estimateStatus").value(responseDto.estimateStatus()))
+				.andExpect(jsonPath("$.data.imagePath").value(responseDto.imagePath()))
+
+				// 사고 레포트 정보
+				.andExpect(jsonPath("$.data.damageReportInfo.description").value(responseDto.damageReportInfo().description()))
+				.andExpect(jsonPath("$.data.damageReportInfo.preferredRepairSido").value(responseDto.damageReportInfo().preferredRepairSido()))
+				.andExpect(jsonPath("$.data.damageReportInfo.preferredRepairSigungu").value(responseDto.damageReportInfo().preferredRepairSigungu()))
+				.andExpect(jsonPath("$.data.damageReportInfo.isPickupRequired").value(responseDto.damageReportInfo().isPickupRequired()))
+
+				// 차량 정보
+				.andExpect(jsonPath("$.data.vehicleInfo.brand").value(responseDto.vehicleInfo().brand()))
+				.andExpect(jsonPath("$.data.vehicleInfo.licenseNumber").value(responseDto.vehicleInfo().licenseNumber()))
+				.andExpect(jsonPath("$.data.vehicleInfo.modelName").value(responseDto.vehicleInfo().modelName()))
+				.andExpect(jsonPath("$.data.vehicleInfo.modelYear").value(responseDto.vehicleInfo().modelYear()))
+				.andExpect(jsonPath("$.data.vehicleInfo.ownerName").value(responseDto.vehicleInfo().ownerName()))
+				.andExpect(jsonPath("$.data.vehicleInfo.ownershipType").value(responseDto.vehicleInfo().ownershipType()))
+				.andDo(restDocsHandler.document(
+						ResourceDocumentation.resource(ResourceSnippetParameters.builder()
+							.tag(BASE_TAG)
+							.summary("견적서 상세 조회")
+							.description("## 견적서 상세 조회 기능 \n"
+								+ "### 설명 \n"
+								+ "- 사고 레포트에 의해 생성된 견적서 정보를 조회합니다.\n"
+							)
+							.responseSchema(Schema.schema(VehicleInfoResponse.class.getSimpleName()))
+							.responseFields(
+								fieldWithPath("message").description("성공 응답 메세지입니다.").type(JsonFieldType.STRING),
+								// 견적서 정보
+								fieldWithPath("data.estimateId").description("견적서 식별자입니다.").type(JsonFieldType.NUMBER),
+								fieldWithPath("data.repairCost").description("사고 견적 분석 금액입니다.").type(JsonFieldType.NUMBER),
+								fieldWithPath("data.repairParts").description("사고 수리 예상 부위입니다.").type(JsonFieldType.ARRAY),
+								fieldWithPath("data.estimateStatus").description("견적서의 상태입니다.").type(JsonFieldType.STRING),
+								fieldWithPath("data.imagePath").description("견적서의 사고 분석 사진 주소입니다.").type(JsonFieldType.STRING),
+								fieldWithPath("data.createdAt").description("견적서 생성일 입니다.").type(JsonFieldType.STRING),
+
+								// 사고 레포트 정보
+								fieldWithPath("data.damageReportInfo.description").description("사용자가 기술한 사고 레포트의 내용입니다.").type(JsonFieldType.STRING),
+								fieldWithPath("data.damageReportInfo.preferredRepairSido").description("수리 희망 시/도 입니다.").type(JsonFieldType.STRING),
+								fieldWithPath("data.damageReportInfo.preferredRepairSigungu").description("수리 희망 시/군/구 입니다.").type(JsonFieldType.STRING),
+								fieldWithPath("data.damageReportInfo.isPickupRequired").description("사고 수리 픽업 희망 유무입니다.").type(JsonFieldType.BOOLEAN),
+
+								// 차량 정보
+								fieldWithPath("data.vehicleInfo.brand").description("차량의 브랜드입니다.").type(JsonFieldType.STRING),
+								fieldWithPath("data.vehicleInfo.licenseNumber").description("차량의 번호입니다.").type(JsonFieldType.STRING),
+								fieldWithPath("data.vehicleInfo.modelName").description("차량의 모델명입니다.").type(JsonFieldType.STRING),
+								fieldWithPath("data.vehicleInfo.modelYear").description("차량의 연입니다.").type(JsonFieldType.NUMBER),
+								fieldWithPath("data.vehicleInfo.ownerName").description("차량의 실소유자명입니다.").type(JsonFieldType.STRING),
+								fieldWithPath("data.vehicleInfo.ownershipType").description("차량의 유형입니다.").type(JsonFieldType.STRING)
+							)
+							.build()
+						)
+					)
+				);
+		}
+
+		@Test
+		void 견적서_상세_조회_4XX_견적서를_찾지_못한_경우() throws Exception {
+			String errorMessage = Estimate.class.getSimpleName() + "을(를) 찾을 수 없습니다.";
+			Long estimateId = 300L;
+
+			Mockito.doThrow(new NotFoundException(Estimate.class))
+				.when(estimateService).findEstimateDetail(estimateId);
+
+			Estimate estimate = EstimateFixture.ESTIMATE_FIXTURE_1.create();
+			EstimateDetailResponse responseDto = new EstimateDetailResponse(estimate);
+
+			//when
+			ResultActions actions = mockMvc.perform(
+				get(BASE_URI+ "/{estimateId}", estimateId)
+			);
+
+			//then
+			actions
+				.andExpect(status().isNotFound())
+				.andExpect(result -> Assertions.assertInstanceOf(NotFoundException.class, result.getResolvedException()))
+				.andExpect(jsonPath("$.message").value(errorMessage))
+				.andDo(restDocsHandler.document(
+						ResourceDocumentation.resource(ResourceSnippetParameters.builder()
+							.tag(BASE_TAG)
+							.responseSchema(Schema.schema(ApiErrorResponse.class.getSimpleName()))
+							.build())
+					)
+				);
+		}
+	}
+}

--- a/src/test/java/com/carumuch/capstone/identity/presentation/AuthControllerTest.java
+++ b/src/test/java/com/carumuch/capstone/identity/presentation/AuthControllerTest.java
@@ -44,8 +44,6 @@ class AuthControllerTest extends RestDocsSupport {
 
 	private static final String BASE_URI = "/auth";
 	private static final String BASE_TAG = "Identity - Auth";
-	private static final String BASE_SUCCESS_MESSAGE = "OK";
-	private static final String BASE_FIELD_ERROR_MESSAGE = "의 필드 값 유효하지 않습니다.";
 
     private static final String TEST_ACCESS_TOKEN = "accessabcdefghijklmnopqrstuvwxyz";
     private static final String TEST_REFRESH_TOKEN = "refreshabcdefghijklmnopqrstuvwxyz";

--- a/src/test/java/com/carumuch/capstone/identity/presentation/UserControllerTest.java
+++ b/src/test/java/com/carumuch/capstone/identity/presentation/UserControllerTest.java
@@ -42,8 +42,6 @@ class UserControllerTest extends RestDocsSupport {
 
 	private static final String BASE_URI = "/users";
 	private static final String BASE_TAG = "Identity - User";
-	private static final String BASE_SUCCESS_MESSAGE = "OK";
-	private static final String BASE_FIELD_ERROR_MESSAGE = "의 필드 값 유효하지 않습니다.";
 
 	@Nested
 	@DisplayName("회원가입 API 테스트")

--- a/src/test/java/com/carumuch/capstone/support/RestDocsSupport.java
+++ b/src/test/java/com/carumuch/capstone/support/RestDocsSupport.java
@@ -6,6 +6,8 @@ import com.carumuch.capstone.damage.application.DamageReportService;
 import com.carumuch.capstone.damage.application.VehicleService;
 import com.carumuch.capstone.damage.presentation.DamageReportController;
 import com.carumuch.capstone.damage.presentation.VehicleController;
+import com.carumuch.capstone.estimate.application.EstimateService;
+import com.carumuch.capstone.estimate.presentation.EstimateController;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.carumuch.capstone.identity.application.AccountRecoveryService;
 import com.carumuch.capstone.common.infrastructure.config.SecurityConfig;
@@ -50,7 +52,8 @@ import java.util.Optional;
 	UserController.class,
 	AuthController.class,
 	VehicleController.class,
-	DamageReportController.class
+	DamageReportController.class,
+	EstimateController.class
 })
 @Import({
 	SecurityConfig.class,
@@ -105,6 +108,9 @@ public abstract class RestDocsSupport {
 
 	@MockitoBean
 	protected DamageReportService damageReportService;
+
+	@MockitoBean
+	protected EstimateService estimateService;
 
     @BeforeEach
     void setUp() {

--- a/src/test/java/com/carumuch/capstone/support/RestDocsSupport.java
+++ b/src/test/java/com/carumuch/capstone/support/RestDocsSupport.java
@@ -61,6 +61,9 @@ import java.util.Optional;
 @AutoConfigureRestDocs
 public abstract class RestDocsSupport {
 
+	protected static final String BASE_SUCCESS_MESSAGE = "OK";
+	protected static final String BASE_FIELD_ERROR_MESSAGE = "의 필드 값 유효하지 않습니다.";
+
     @Value("${cookie.name}")
     protected String REFRESH_TOKEN_COOKIE_NAME;
 

--- a/src/test/java/com/carumuch/capstone/support/fixture/DamageReportFixture.java
+++ b/src/test/java/com/carumuch/capstone/support/fixture/DamageReportFixture.java
@@ -4,23 +4,25 @@ import com.carumuch.capstone.damage.domain.report.DamageReport;
 import com.carumuch.capstone.damage.domain.report.RepairRegion;
 
 public enum DamageReportFixture {
-	DAMAGE_REPORT_FIXTURE_1("소화전을 박았습니다.", new RepairRegion("서울시", "송파구"), false, "http://s3.image.test1"),
-	DAMAGE_REPORT_FIXTURE_2("야구공에 맞았습니다.", new RepairRegion("서울시", "강남구"), true, "http://s3.image.test2"),
-	DAMAGE_REPORT_FIXTURE_3("아내가 주차장 벽을 긁었습니다.", new RepairRegion("경기도", "고양시"), false, "http://s3.image.test3");
+	DAMAGE_REPORT_FIXTURE_1("소화전을 박았습니다.", new RepairRegion("서울시", "송파구"), false, "http://s3.image.test1", 10L),
+	DAMAGE_REPORT_FIXTURE_2("야구공에 맞았습니다.", new RepairRegion("서울시", "강남구"), true, "http://s3.image.test2", 11L),
+	DAMAGE_REPORT_FIXTURE_3("아내가 주차장 벽을 긁었습니다.", new RepairRegion("경기도", "고양시"), false, "http://s3.image.test3", 12L);
 
 	private final String description;
 	private final RepairRegion preferredRepairRegion;
 	private final boolean isPickupRequired;
 	private final String imagePath;
+	private final Long userId;
 
-	DamageReportFixture(String description, RepairRegion preferredRepairRegion, boolean isPickupRequired, String imagePath) {
+	DamageReportFixture(String description, RepairRegion preferredRepairRegion, boolean isPickupRequired, String imagePath, Long userId) {
 		this.description = description;
 		this.preferredRepairRegion = preferredRepairRegion;
 		this.isPickupRequired = isPickupRequired;
 		this.imagePath = imagePath;
+		this.userId = userId;
 	}
 
 	public DamageReport create() {
-		return new DamageReport(description, preferredRepairRegion, isPickupRequired, imagePath, VehicleFixture.VEHICLE_FIXTURE_1.create());
+		return new DamageReport(description, preferredRepairRegion, isPickupRequired, imagePath, VehicleFixture.VEHICLE_FIXTURE_1.create(), userId);
 	}
 }

--- a/src/test/java/com/carumuch/capstone/support/fixture/EstimateFixture.java
+++ b/src/test/java/com/carumuch/capstone/support/fixture/EstimateFixture.java
@@ -1,0 +1,54 @@
+package com.carumuch.capstone.support.fixture;
+
+import java.util.Set;
+
+import com.carumuch.capstone.estimate.domain.Estimate;
+import com.carumuch.capstone.estimate.domain.EstimateStatus;
+
+public enum EstimateFixture {
+	ESTIMATE_FIXTURE_1(
+		10_000,
+		Set.of("프론트휠 (좌)", "프론트도어 (좌)", "사이드미러 (좌)"),
+		EstimateStatus.OPEN,
+		"http://test-image1.com"
+	),
+	ESTIMATE_FIXTURE_2(
+		20_000,
+		Set.of("프론트휠 (우)", "프론트도어 (우)", "사이드미러 (우)"),
+		EstimateStatus.CLOSED,
+		"http://test-image2.com"
+	),
+	ESTIMATE_FIXTURE_3(
+		30_000,
+		Set.of("백휠 (우)", "백도어 (우)", "사이드미러 (좌)"),
+		EstimateStatus.PRIVATE,
+		"http://test-image3.com"
+	);
+
+	private final Integer repairCost;
+	private final Set<String> repairParts;
+	private final EstimateStatus estimateStatus;
+	private final String imagePath;
+
+	EstimateFixture(
+		Integer repairCost,
+		Set<String> repairParts,
+		EstimateStatus estimateStatus,
+		String imagePath
+	) {
+		this.repairCost = repairCost;
+		this.repairParts = repairParts;
+		this.estimateStatus = estimateStatus;
+		this.imagePath = imagePath;
+	}
+
+	public Estimate create() {
+		return new Estimate(
+			repairCost,
+			repairParts,
+			estimateStatus,
+			imagePath,
+			DamageReportFixture.DAMAGE_REPORT_FIXTURE_1.create()
+		);
+	}
+}

--- a/src/test/java/com/carumuch/capstone/support/fixture/EstimateFixture.java
+++ b/src/test/java/com/carumuch/capstone/support/fixture/EstimateFixture.java
@@ -23,6 +23,12 @@ public enum EstimateFixture {
 		Set.of("백휠 (우)", "백도어 (우)", "사이드미러 (좌)"),
 		EstimateStatus.PRIVATE,
 		"http://test-image3.com"
+	),
+	ESTIMATE_FIXTURE_4(
+		30_000,
+		Set.of("백휠 (우)", "백도어 (우)", "사이드미러 (좌)"),
+		EstimateStatus.OPEN,
+		"http://test-image4.com"
 	);
 
 	private final Integer repairCost;


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [X] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [X] 코드 리팩토링
- [ ] 테스트 코드 추가 및 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
develop

### 이슈
[#88](이슈 링크)

### 변경 사항
### 1. estimate 상세 조회 기능

사고레포트와 사고 차량 정보를 견적서 정보와 함께 조회합니다.
사용자가 자신의 견적 이력을 확인하거나, 공업사 직원이 입찰하고 싶은 견적서를 조회하기 위한 기능입니다.


### 2. estimate 상태 업데이트 기능  

견적서는 다음 3가지 상태를 가집니다.

- OPEN  
  → 공개 입찰이 가능한 상태 (공업사들이 조회 가능)

- PRIVATE  
  → 공개 입찰을 받지 않고 개인 히스토리로 보관하는 상태

- CLOSED  
  → 낙찰 완료되어 더 이상 입찰을 받을 수 없는 마감 상태

비즈니스 정책상, CLOSED 상태의 견적서는 사용자가 임의로 변경할 수 없습니다.  
따라서 사용자는 OPEN ↔ PRIVATE 상태만 변경할 수 있도록 제한했습니다.


### 3. estimate 조건(필터링) 검색 기능  

공개 입찰을 위한 견적서 검색 기능을 추가했습니다.  
다양한 검색 조건을 유연하게 조합하기 위해 QueryDSL 기반 동적 쿼리로 구현했습니다.

QueryDSL을 선택한 이유는 다음과 같습니다.

- JPA 기반 프로젝트와의 높은 호환성  

추가적으로, QueryDSL 5.x 버전에 SQL Injection 관련 보안 이슈가 보고된 바 있어  
추후 6.x 버전 마이그레이션을 검토할 예정입니다.
(현재는 기존 프로젝트 의존성과 구축 난이도를 고려하여 5.x를 유지했습니다.)

MyBatis 등 다른 동적 쿼리 기술을 사용안한 이유

- 현재 프로젝트가 JPA 중심으로 설계되어 있음  
- 영속성 컨텍스트 및 엔티티 기반 모델을 그대로 활용하는 것이 일관성 측면에서 유리하다고 판단
- 현재의 프로젝트 구조에 SQL Mapper 계층을 추가할 경우 복잡도가 증가할 수 있다고 판단  

### 테스트 결과
<img width="829" height="235" alt="스크린샷 2026-02-04 오후 9 32 30" src="https://github.com/user-attachments/assets/b013c9fc-5902-47c6-a2c9-fc774e001c5d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 견적서 상세 조회 추가 (ID 또는 사고레포트 기반) — 이미지·차량·사고 정보 포함
  * 조건 검색 강화: 수리비·지역·브랜드·연식·픽업여부 등, 페이징·정렬(인기순 포함)
  * 견적서 상태 변경 API 추가(상태 전환 검증 포함)

* **보안**
  * 견적서 조회·검색·상태 변경 엔드포인트 인증 필수화

* **오류 처리**
  * 상태 변경 유효성 및 접근 권한 검사 강화(부적절 전환에 400, 권한 없으면 403 반환)

* **테스트**
  * 서비스·컨트롤러 단위·통합 테스트 및 REST Docs 문서화 보강
<!-- end of auto-generated comment: release notes by coderabbit.ai -->