### PR TITLE
[#98] AI mock 인프라 docker compose 작성

### DIFF
--- a/infrastructure/docker-compose-ai.yml
+++ b/infrastructure/docker-compose-ai.yml
@@ -19,7 +19,7 @@ services:
       retries: 10
 
   ai-mock:
-    image: fprh13/caumuch-mock-ai:0.0.1
+    image: fprh13/carumuch-mock-ai:0.0.1
     container_name: carumuch-ai-mock
     depends_on:
       rabbitmq:

--- a/infrastructure/docker-compose-ai.yml
+++ b/infrastructure/docker-compose-ai.yml
@@ -1,0 +1,28 @@
+version: "3.8"
+
+services:
+  rabbitmq:
+    image: rabbitmq:3.13-management
+    container_name: carumuch-rabbitmq
+    environment:
+      RABBITMQ_DEFAULT_USER: ${RABBITMQ_USER}
+      RABBITMQ_DEFAULT_PASS: ${RABBITMQ_PASS}
+    ports:
+      - "5672:5672"
+      - "15672:15672"
+    volumes:
+      - /Users/yeongmujo/Desktop/workSpace/rabbitmq-data:/var/lib/rabbitmq # TODO 현재 로컬에서 관리 중
+    healthcheck:
+      test: ["CMD", "rabbitmq-diagnostics", "-q", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+  ai-mock:
+    image: fprh13/caumuch-mock-ai:0.0.1
+    container_name: carumuch-ai-mock
+    depends_on:
+      rabbitmq:
+        condition: service_healthy
+    ports:
+      - "8081:8081"


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 코드 리팩토링
- [ ] 테스트 코드 추가 및 리팩토링
- [X] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
develop

### 이슈
[#98 ](이슈 링크)

### 변경 사항
AI Mock 서버 인프라 환경을 docker compose를 통해 통합 관리합니다.
RabbitMQ와 AI Mock 서버를 포함합니다.


### 테스트 결과

<img width="537" height="203" alt="스크린샷 2026-02-16 오후 3 23 29" src="https://github.com/user-attachments/assets/e4fe0e18-452b-4fe9-9899-21d13d3467b3" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * 로컬 개발용 도커 컴포즈 구성이 추가되어, 메시지 큐(RabbitMQ)와 AI 모크 서비스가 함께 실행되도록 환경이 마련되었습니다. 메시지 큐에 대한 상태 확인이 포함되어 모크 서비스는 큐가 준비된 후 시작됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->