### PR TITLE
[#100] 공업사 조회 기능 리펙토링

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -277,6 +277,3 @@ openapi3.yaml
 *.jpg
 *.jpeg
 *.png
-
-#AI agent metadata
-*.omx

--- a/src/test/java/com/carumuch/capstone/bodyshop/integration/BodyShopIntegrationTest.java
+++ b/src/test/java/com/carumuch/capstone/bodyshop/integration/BodyShopIntegrationTest.java
@@ -13,6 +13,7 @@ import com.carumuch.capstone.bodyshop.application.BodyShopService;
 import com.carumuch.capstone.bodyshop.domain.BodyShop;
 import com.carumuch.capstone.bodyshop.domain.BodyShopRepository;
 import com.carumuch.capstone.bodyshop.presentation.dto.request.LocationRequest;
+import com.carumuch.capstone.bodyshop.presentation.dto.response.BodyShopInfoResponse;
 import com.carumuch.capstone.bodyshop.presentation.dto.request.RegisterBodyShopRequest;
 import com.carumuch.capstone.bodyshop.presentation.dto.request.UpdateBodyShopRequest;
 import com.carumuch.capstone.common.exception.CustomException;
@@ -285,6 +286,44 @@ public class BodyShopIntegrationTest extends IntegrationSupportTest {
 			//when & then
 			Assertions.assertThatThrownBy(() -> bodyShopService.update(bodyShop.getId(), requestDto, userId))
 				.isInstanceOf(ForbiddenException.class);
+		}
+	}
+
+	@Nested
+	@DisplayName("공업사 조회 기능")
+	class Info {
+		@Test
+		void 공업사를_조회한다() {
+			//given
+			Long bodyShopId = bodyShop.getId();
+
+			//when
+			BodyShopInfoResponse result = bodyShopService.info(bodyShopId);
+
+			//then
+			assertAll(
+				() -> Assertions.assertThat(result.name()).isEqualTo(bodyShop.getName()),
+				() -> Assertions.assertThat(result.description()).isEqualTo(bodyShop.getDescription()),
+				() -> Assertions.assertThat(result.phoneNumber()).isEqualTo(bodyShop.getPhoneNumber().getValue()),
+				() -> Assertions.assertThat(result.link()).isEqualTo(bodyShop.getLink()),
+				() -> Assertions.assertThat(result.locationResponse().sido()).isEqualTo(bodyShop.getLocation().getSido()),
+				() -> Assertions.assertThat(result.locationResponse().sigungu()).isEqualTo(bodyShop.getLocation().getSiqungu()),
+				() -> Assertions.assertThat(result.locationResponse().bname()).isEqualTo(bodyShop.getLocation().getBname()),
+				() -> Assertions.assertThat(result.locationResponse().roadAddress()).isEqualTo(bodyShop.getLocation().getRoadAddress()),
+				() -> Assertions.assertThat(result.locationResponse().jibunAddress()).isEqualTo(bodyShop.getLocation().getJibunAddress()),
+				() -> Assertions.assertThat(result.locationResponse().detail()).isEqualTo(bodyShop.getLocation().getDetail()),
+				() -> Assertions.assertThat(result.pickupAvailable()).isEqualTo(bodyShop.isPickupAvailable())
+			);
+		}
+
+		@Test
+		void 공업사를_찾지_못하면_예외를_반환한다() {
+			//given
+			Long wrongBodyShopId = 9999L;
+
+			//when & then
+			Assertions.assertThatThrownBy(() -> bodyShopService.info(wrongBodyShopId))
+				.isInstanceOf(NotFoundException.class);
 		}
 	}
 }

--- a/src/test/java/com/carumuch/capstone/bodyshop/presentation/BodyShopControllerTest.java
+++ b/src/test/java/com/carumuch/capstone/bodyshop/presentation/BodyShopControllerTest.java
@@ -1,12 +1,9 @@
 package com.carumuch.capstone.bodyshop.presentation;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.mockito.ArgumentMatchers.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
@@ -15,12 +12,14 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.ResultActions;
 
 import com.carumuch.capstone.bodyshop.domain.BodyShop;
 import com.carumuch.capstone.bodyshop.presentation.dto.request.LocationRequest;
 import com.carumuch.capstone.bodyshop.presentation.dto.request.RegisterBodyShopRequest;
 import com.carumuch.capstone.bodyshop.presentation.dto.request.UpdateBodyShopRequest;
+import com.carumuch.capstone.bodyshop.presentation.dto.response.BodyShopInfoResponse;
 import com.carumuch.capstone.common.exception.NotFoundException;
 import com.carumuch.capstone.common.presentation.dto.ApiErrorResponse;
 import com.carumuch.capstone.common.presentation.dto.ApiResponse;
@@ -200,6 +199,91 @@ class BodyShopControllerTest extends RestDocsSupport {
 					ResourceDocumentation.resource(ResourceSnippetParameters.builder()
 						.tag(BASE_TAG)
 						.requestSchema(Schema.schema(UpdateBodyShopRequest.class.getSimpleName()))
+						.responseSchema(Schema.schema(ApiErrorResponse.class.getSimpleName()))
+						.build())
+					)
+				);
+		}
+	}
+
+	@Nested
+	@DisplayName("공업사 조회 API 테스트")
+	class Info {
+		@Test
+		void 공업사_조회_2XX() throws Exception {
+			//given
+			Long bodyShopId = 1L;
+			BodyShop bodyShop = BodyShopFixture.BODY_SHOP_FIXTURE_1.create(1L);
+			ReflectionTestUtils.setField(bodyShop, "id", bodyShopId);
+
+			BodyShopInfoResponse responseDto = BodyShopInfoResponse.from(bodyShop);
+
+			Mockito.when(bodyShopService.info(anyLong()))
+				.thenReturn(responseDto);
+
+			//when
+			ResultActions actions = mockMvc.perform(
+				get(BASE_URI + "/{bodyShopId}", bodyShopId)
+					.contentType(MediaType.APPLICATION_JSON));
+
+			//then
+			actions
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.message").value(BASE_SUCCESS_MESSAGE))
+				.andExpect(jsonPath("$.data.name").value(responseDto.name()))
+				.andDo(restDocsHandler.document(
+					ResourceDocumentation.resource(ResourceSnippetParameters.builder()
+						.tag(BASE_TAG)
+						.summary("공업사 상세 조회")
+						.description("## 공업사 상세 조회 기능 \n"
+							+ "### 설명 \n"
+							+ "- 공업사 식별자를 통해 공업사의 상세 정보를 조회합니다."
+						)
+						.responseSchema(Schema.schema(BodyShopInfoResponse.class.getSimpleName()))
+						.responseFields(
+							fieldWithPath("message").description("응답 메시지입니다.").type(JsonFieldType.STRING),
+							fieldWithPath("data.id").description("공업사 식별자입니다.").type(JsonFieldType.NUMBER),
+							fieldWithPath("data.name").description("공업사 이름입니다.").type(JsonFieldType.STRING),
+							fieldWithPath("data.description").description("공업사 소개입니다.").type(JsonFieldType.STRING),
+							fieldWithPath("data.phoneNumber").description("공업사 연락처입니다.").type(JsonFieldType.STRING),
+							fieldWithPath("data.locationResponse.sido").description("공업사 소재지 시/도입니다.").type(JsonFieldType.STRING),
+							fieldWithPath("data.locationResponse.sigungu").description("공업사 소재지 시/군/구입니다.").type(JsonFieldType.STRING),
+							fieldWithPath("data.locationResponse.bname").description("공업사 소재지 법정동명입니다.").type(JsonFieldType.STRING),
+							fieldWithPath("data.locationResponse.jibunAddress").description("공업사 지번 주소입니다.").type(JsonFieldType.STRING),
+							fieldWithPath("data.locationResponse.roadAddress").description("공업사 도로명 주소입니다.").type(JsonFieldType.STRING),
+							fieldWithPath("data.locationResponse.detail").description("공업사 상세 주소입니다.").type(JsonFieldType.STRING),
+							fieldWithPath("data.link").description("공업사 관련 링크입니다.").type(JsonFieldType.STRING),
+							fieldWithPath("data.acceptCount").description("공업사 낙찰 횟수입니다.").type(JsonFieldType.NUMBER),
+							fieldWithPath("data.pickupAvailable").description("차량 픽업 가능 여부입니다.").type(JsonFieldType.BOOLEAN)
+						)
+						.build())
+					)
+				);
+		}
+
+		@Test
+		void 공업사_조회_4XX_공업사를_찾지_못한_경우() throws Exception {
+			//given
+			Long bodyShopId = 1L;
+			String errorMessage = BodyShop.class.getSimpleName() + "을(를) 찾을 수 없습니다.";
+
+			Mockito.doThrow(new NotFoundException(BodyShop.class))
+				.when(bodyShopService)
+				.info(anyLong());
+
+			//when
+			ResultActions actions = mockMvc.perform(
+				get(BASE_URI + "/{bodyShopId}", bodyShopId)
+					.contentType(MediaType.APPLICATION_JSON));
+
+			//then
+			actions
+				.andExpect(status().isNotFound())
+				.andExpect(result -> Assertions.assertInstanceOf(NotFoundException.class, result.getResolvedException()))
+				.andExpect(jsonPath("$.message").value(errorMessage))
+				.andDo(restDocsHandler.document(
+					ResourceDocumentation.resource(ResourceSnippetParameters.builder()
+						.tag(BASE_TAG)
 						.responseSchema(Schema.schema(ApiErrorResponse.class.getSimpleName()))
 						.build())
 					)


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [X] 코드 리팩토링
- [ ] 테스트 코드 추가 및 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
develop

### 이슈
Closes #100

### 변경 사항
공업사 단건 조회 기능에 대해서 리펙토링을 진행합니다.
공업사 단건 조회의 리펙토링 사항이 이전 PR에 포함되었습니다.
따라서, 테스트만 추가 되었습니다.

### 추가 참고 사항
혼자서 하는 프로젝트라는 이유로 PR 단위와 이슈 추적에 소홀해진것 같습니다.
따라서, 다음 작업 시에는 아래와 같은 작업을 진행할 예정이오니 참고바랍니다.
1. 마일스톤 단위 개선
2. 이슈 단위 개선
3. 이슈 템플릿 개선
4. PR 템플릿 개선
5. 개인 Notion -> Github Projects

### 테스트 결과
<img width="704" height="441" alt="스크린샷 2026-04-14 오후 6 52 37" src="https://github.com/user-attachments/assets/f5796bb8-46a8-439c-82e5-29a1d63cf6d4" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **테스트**
  * 공업사 정보 조회 기능에 대한 통합 테스트 추가
  * 공업사 조회 API의 성공 및 실패 케이스에 대한 컨트롤러 테스트 추가

* **기타**
  * 프로젝트 설정 파일 조정

<!-- end of auto-generated comment: release notes by coderabbit.ai -->