### PR TITLE
[#119] codex Rules 작성

### DIFF
--- a/.codex/rules/default.rules
+++ b/.codex/rules/default.rules
@@ -1,0 +1,115 @@
+# --------------------------------------------------
+#                       허용
+# --------------------------------------------------
+
+# 프로젝트 검증 스크립트는 반복 확인 없이 허용
+prefix_rule(
+  pattern = ["bash", "scripts/verify.sh"],
+  decision = "allow",
+  justification = "프로젝트 표준 검증 진입점입니다.",
+  match = [
+    "bash scripts/verify.sh",
+  ],
+  not_match = [
+    "bash ./scripts/verify.sh",
+    "bash scripts/other.sh",
+  ],
+)
+
+# verify 스크립트에서 사용하는 Gradle 테스트 명령 허용
+prefix_rule(
+  pattern = ["./gradlew", "test"],
+  decision = "allow",
+  justification = "이 저장소의 표준 품질 검증 명령입니다.",
+  match = [
+    "./gradlew test",
+    "./gradlew test -DexcludeTags=integration",
+  ],
+  not_match = [
+    "./gradlew build",
+    "./gradlew clean test",
+  ],
+)
+
+# --------------------------------------------------
+#                       확인
+# --------------------------------------------------
+
+# 커밋 생성 전에는 사용자 확인 요청
+prefix_rule(
+  pattern = ["git", "commit"],
+  decision = "prompt",
+  justification = "커밋은 사용자 검토 후 수행되어야 합니다.",
+  match = [
+    "git commit -m chore",
+    "git commit --amend",
+  ],
+  not_match = [
+    "git status",
+    "git add .",
+  ],
+)
+
+# 푸시 전에는 사용자 확인 요청
+prefix_rule(
+  pattern = ["git", "push"],
+  decision = "prompt",
+  justification = "푸시는 항상 검토 후 수행되어야 합니다.",
+  match = [
+    "git push",
+    "git push origin main",
+  ],
+  not_match = [
+    "git pull",
+    "git status",
+  ],
+)
+
+# --------------------------------------------------
+#                       금지
+# --------------------------------------------------
+
+# 강제 푸시는 금지
+prefix_rule(
+  pattern = ["git", "push", "--force"],
+  decision = "forbidden",
+  justification = "Codex에서 원격 히스토리를 덮어쓰면 안 됩니다. 일반 push를 사용하거나 수동으로 처리해야 합니다.",
+  match = [
+    "git push --force",
+    "git push --force origin feature-branch",
+  ],
+  not_match = [
+    "git push",
+    "git push --tags",
+  ],
+)
+
+# hard reset 금지
+prefix_rule(
+  pattern = ["git", "reset", "--hard"],
+  decision = "forbidden",
+  justification = "hard reset은 위험합니다. 더 안전한 복구 절차를 수동으로 사용해야 합니다.",
+  match = [
+    "git reset --hard",
+    "git reset --hard HEAD~1",
+  ],
+  not_match = [
+    "git reset --soft HEAD~1",
+    "git restore .",
+  ],
+)
+
+# 재귀 삭제 금지
+prefix_rule(
+  pattern = ["rm", "-rf", ["/", "."]],
+  decision = "forbidden",
+  justification = "위험한 재귀 삭제는 항상 금지됩니다.",
+  match = [
+    "rm -rf /",
+    "rm -rf .",
+  ],
+  not_match = [
+    "rm -rf build",
+    "rm -rf .gradle",
+  ],
+)

--- a/.codex/rules/default.rules
+++ b/.codex/rules/default.rules
@@ -58,6 +58,7 @@ prefix_rule(
   match = [
     "git push",
     "git push origin main",
+    "git push origin feature/my-branch",
   ],
   not_match = [
     "git pull",
@@ -71,18 +72,22 @@ prefix_rule(
 
 # 강제 푸시는 금지
 prefix_rule(
-  pattern = ["git", "push", "--force"],
+  pattern = ["git", "push", ["-f", "--force", "--force-with-lease", "--force-if-includes"]],
   decision = "forbidden",
   justification = "Codex에서 원격 히스토리를 덮어쓰면 안 됩니다. 일반 push를 사용하거나 수동으로 처리해야 합니다.",
   match = [
-    "git push --force",
-    "git push --force origin feature-branch",
-  ],
-  not_match = [
-    "git push",
-    "git push --tags",
-  ],
-)
+      "git push -f",
+      "git push --force",
+      "git push --force origin feature-branch",
+      "git push --force-with-lease",
+      "git push --force-if-includes",
+    ],
+    not_match = [
+      "git push",
+      "git push --tags",
+      "git push origin main",
+    ],
+  )
 
 # hard reset 금지
 prefix_rule(


### PR DESCRIPTION
## 🔗 관련 이슈
Closes #119 

---

## 변경 내용
- Codex Rules를 작성했습니다.
- 허용, 확인, 금지로 나누어진 Rules입니다.

---

## 변경 이유
AI agentic tool을 사용할 때 위험한 명령어에 대한 명시적인 제한을 두지 않으면 위험합니다. (ex: rm, git push)
Open AI 의 공식 문서에서도 *.rules에 명령어 정책을 작성하도록 소개 되어있기 때문에 작성하게 되었습니다.

---

## 테스트
- [x] 로컬 테스트 완료 

---

## 체크리스트
- [x] self review 완료
- [x] 불필요한 코드 제거 완료
- [x] 네이밍 / 컨벤션 확인 완료

---
## 참고 사항




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 저장소 검증 및 테스트 실행을 위한 기본 명령 규칙 설정 추가
  * Git 커밋 및 푸시 작업 전 사용자 확인 프롬프트 추가
  * 위험한 Git 강제 푸시, 하드 리셋, 재귀 삭제 명령어 차단

<!-- end of auto-generated comment: release notes by coderabbit.ai -->