### PR TITLE
[#125] codex 검증 hooks 추가

### DIFF
--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,0 +1,27 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/usr/bin/python3 \"$(git rev-parse --show-toplevel)/.codex/hooks/pre_tool_policy.py\"",
+            "statusMessage": "Checking command policy"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/usr/bin/python3 \"$(git rev-parse --show-toplevel)/.codex/hooks/stop_retry.py\"",
+            "timeout": 20
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -7,6 +7,7 @@
           {
             "type": "command",
             "command": "/usr/bin/python3 \"$(git rev-parse --show-toplevel)/.codex/hooks/pre_tool_policy.py\"",
+            "timeout": 20,
             "statusMessage": "Checking command policy"
           }
         ]

--- a/.codex/hooks/pre_tool_policy.py
+++ b/.codex/hooks/pre_tool_policy.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+import json
+import sys
+
+
+BLOCKED_PATTERNS = [
+    "git push --force",
+    "rm -rf /",
+    "rm -rf .",
+    "sudo",
+]
+
+
+def main():
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:
+        sys.exit(0)
+
+    tool_input = payload.get("tool_input", {})
+    command = tool_input.get("command", "")
+
+    if not command:
+        sys.exit(0)
+
+    for pattern in BLOCKED_PATTERNS:
+        if pattern in command:
+            print(json.dumps({
+                "decision": "block",
+                "reason": f"Blocked dangerous command: {pattern}"
+            }))
+            sys.exit(0)
+
+    # allow는 출력하지 않고 그냥 통과
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/.codex/hooks/pre_tool_policy.py
+++ b/.codex/hooks/pre_tool_policy.py
@@ -60,8 +60,11 @@ def main():
     for reason, predicate in BLOCKED_COMMAND_CHECKS:
         if predicate(tokens):
             print(json.dumps({
-                "decision": "block",
-                "reason": f"Blocked dangerous command: {reason}"
+                "hookSpecificOutput": {
+                    "hookEventName": "PreToolUse",
+                    "permissionDecision": "deny",
+                    "permissionDecisionReason": f"Blocked dangerous command: {reason}",
+                }
             }))
             sys.exit(0)
 

--- a/.codex/hooks/pre_tool_policy.py
+++ b/.codex/hooks/pre_tool_policy.py
@@ -1,14 +1,46 @@
 #!/usr/bin/env python3
 import json
+import shlex
 import sys
 
 
-BLOCKED_PATTERNS = [
-    "git push --force",
-    "rm -rf /",
-    "rm -rf .",
-    "sudo",
+FORCE_PUSH_FLAGS = {"--force", "--force-with-lease", "-f"}
+BLOCKED_COMMAND_CHECKS = [
+    ("git push with force", lambda tokens: is_force_push(tokens)),
+    ("rm with recursive force on / or .", lambda tokens: is_dangerous_rm(tokens)),
+    ("sudo", lambda tokens: is_sudo_command(tokens)),
 ]
+
+
+def parse_command(command):
+    if isinstance(command, list):
+        return [str(part) for part in command]
+
+    try:
+        return shlex.split(str(command or ""))
+    except ValueError:
+        return str(command or "").split()
+
+
+def is_force_push(tokens):
+    if len(tokens) < 3 or tokens[0] != "git" or tokens[1] != "push":
+        return False
+
+    return any(token in FORCE_PUSH_FLAGS or token.startswith("--force=") for token in tokens[2:])
+
+
+def is_dangerous_rm(tokens):
+    if not tokens or tokens[0] != "rm":
+        return False
+
+    flags = [token for token in tokens[1:] if token.startswith("-")]
+    targets = [token for token in tokens[1:] if not token.startswith("-")]
+    has_recursive_force = any("r" in flag and "f" in flag for flag in flags)
+    return has_recursive_force and any(target in {"/", "."} for target in targets)
+
+
+def is_sudo_command(tokens):
+    return bool(tokens) and tokens[0] == "sudo"
 
 
 def main():
@@ -23,11 +55,13 @@ def main():
     if not command:
         sys.exit(0)
 
-    for pattern in BLOCKED_PATTERNS:
-        if pattern in command:
+    tokens = parse_command(command)
+
+    for reason, predicate in BLOCKED_COMMAND_CHECKS:
+        if predicate(tokens):
             print(json.dumps({
                 "decision": "block",
-                "reason": f"Blocked dangerous command: {pattern}"
+                "reason": f"Blocked dangerous command: {reason}"
             }))
             sys.exit(0)
 

--- a/.codex/hooks/pre_tool_policy.py
+++ b/.codex/hooks/pre_tool_policy.py
@@ -22,11 +22,26 @@ def parse_command(command):
         return str(command or "").split()
 
 
+def has_short_flag(token, flag):
+    return token.startswith("-") and not token.startswith("--") and flag in token[1:]
+
+
 def is_force_push(tokens):
-    if len(tokens) < 3 or tokens[0] != "git" or tokens[1] != "push":
+    if len(tokens) < 3 or tokens[0] != "git":
         return False
 
-    return any(token in FORCE_PUSH_FLAGS or token.startswith("--force=") for token in tokens[2:])
+    try:
+        push_index = tokens.index("push", 1)
+    except ValueError:
+        return False
+
+    return any(
+        token in FORCE_PUSH_FLAGS
+        or token.startswith("--force=")
+        or token.startswith("--force-with-lease=")
+        or has_short_flag(token, "f")
+        for token in tokens[push_index + 1:]
+    )
 
 
 def is_dangerous_rm(tokens):
@@ -35,8 +50,17 @@ def is_dangerous_rm(tokens):
 
     flags = [token for token in tokens[1:] if token.startswith("-")]
     targets = [token for token in tokens[1:] if not token.startswith("-")]
-    has_recursive_force = any("r" in flag and "f" in flag for flag in flags)
-    return has_recursive_force and any(target in {"/", "."} for target in targets)
+    has_recursive = any(
+        flag in {"-r", "-R", "--recursive"} or has_short_flag(flag, "r") or has_short_flag(flag, "R")
+        for flag in flags
+    )
+    has_force = any(
+        flag in {"-f", "--force"}
+        or flag.startswith("--force=")
+        or has_short_flag(flag, "f")
+        for flag in flags
+    )
+    return has_recursive and has_force and any(target in {"/", ".", "./"} for target in targets)
 
 
 def is_sudo_command(tokens):

--- a/.codex/hooks/stop_retry.py
+++ b/.codex/hooks/stop_retry.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+STATE_PATH = PROJECT_ROOT / "state" / "retry_state.json"
+MAX_RETRIES = 3
+BACKEND_CHANGE_PATTERN = re.compile(
+    r"^(src/|build\.gradle|build\.gradle\.kts|settings\.gradle|settings\.gradle\.kts|gradle/|gradlew|gradlew\.bat)"
+)
+VERIFY_COMMAND_PATTERN = re.compile(r"(^|[ /])(\.?/)?scripts/verify\.sh($|[ \"'])")
+
+
+def load_state():
+    if not STATE_PATH.exists():
+        return {"count": 0, "last_counted_turn_id": None}
+
+    try:
+        state = json.loads(STATE_PATH.read_text())
+        return {
+            "count": int(state.get("count", 0)),
+            "last_counted_turn_id": state.get("last_counted_turn_id"),
+        }
+    except Exception:
+        return {"count": 0, "last_counted_turn_id": None}
+
+
+def save_state(state):
+    STATE_PATH.parent.mkdir(parents=True, exist_ok=True)
+    STATE_PATH.write_text(json.dumps(state, indent=2))
+
+
+def reset_state():
+    save_state({"count": 0, "last_counted_turn_id": None})
+
+
+def get_staged_files():
+    proc = subprocess.run(
+        ["git", "diff", "--cached", "--name-only"],
+        cwd=PROJECT_ROOT,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        text=True,
+        check=False,
+    )
+    return [line.strip() for line in proc.stdout.splitlines() if line.strip()]
+
+
+def has_backend_related_changes():
+    return any(BACKEND_CHANGE_PATTERN.match(path) for path in get_staged_files())
+
+
+def is_verify_command(command):
+    if isinstance(command, list):
+        command_text = " ".join(str(part) for part in command)
+    else:
+        command_text = str(command or "")
+
+    return bool(VERIFY_COMMAND_PATTERN.search(command_text))
+
+
+def get_latest_verify_result(transcript_path, turn_id):
+    if not transcript_path:
+        return None
+
+    path = Path(transcript_path)
+    if not path.exists():
+        return None
+
+    latest = None
+    with path.open() as transcript:
+        for line in transcript:
+            try:
+                event = json.loads(line)
+            except Exception:
+                continue
+
+            if event.get("type") != "event_msg":
+                continue
+
+            payload = event.get("payload", {})
+            if payload.get("type") != "exec_command_end":
+                continue
+
+            if payload.get("turn_id") != turn_id:
+                continue
+
+            if not is_verify_command(payload.get("command")):
+                continue
+
+            latest = {
+                "exit_code": payload.get("exit_code"),
+                "output": payload.get("aggregated_output", "")[-4000:],
+            }
+
+    return latest
+
+
+def block(reason):
+    print(json.dumps({
+        "decision": "block",
+        "reason": reason,
+    }))
+
+
+def main():
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:
+        sys.exit(0)
+
+    if payload.get("stop_hook_active"):
+        sys.exit(0)
+
+    if not has_backend_related_changes():
+        reset_state()
+        sys.exit(0)
+
+    turn_id = payload.get("turn_id")
+    transcript_path = payload.get("transcript_path")
+    verify_result = get_latest_verify_result(transcript_path, turn_id)
+
+    if verify_result is None:
+        block(
+            "백엔드 관련 변경이 감지되었습니다.\n\n"
+            "종료하기 전에 `bash scripts/verify.sh`를 먼저 실행하고 결과를 확인하세요."
+        )
+        sys.exit(0)
+
+    if verify_result.get("exit_code") == 0:
+        reset_state()
+        sys.exit(0)
+
+    state = load_state()
+    count = state.get("count", 0)
+    if state.get("last_counted_turn_id") != turn_id:
+        count += 1
+        state["count"] = count
+        state["last_counted_turn_id"] = turn_id
+        save_state(state)
+
+    if count >= MAX_RETRIES:
+        block(
+            "Verification failed after maximum retries.\n\n"
+            f"Retry count: {count}/{MAX_RETRIES}\n\n"
+            "Fix manually."
+        )
+        sys.exit(0)
+
+    block(
+        "Verification failed.\n\n"
+        f"Retry count: {count}/{MAX_RETRIES}\n\n"
+        "Fix the root cause and run again.\n\n"
+        "Recent output:\n"
+        f"{verify_result.get('output', '')}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/.codex/hooks/stop_retry.py
+++ b/.codex/hooks/stop_retry.py
@@ -50,8 +50,21 @@ def get_staged_files():
     return [line.strip() for line in proc.stdout.splitlines() if line.strip()]
 
 
+def get_unstaged_files():
+    proc = subprocess.run(
+        ["git", "diff", "--name-only"],
+        cwd=PROJECT_ROOT,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        text=True,
+        check=False,
+    )
+    return [line.strip() for line in proc.stdout.splitlines() if line.strip()]
+
+
 def has_backend_related_changes():
-    return any(BACKEND_CHANGE_PATTERN.match(path) for path in get_staged_files())
+    changed_files = set(get_staged_files()) | set(get_unstaged_files())
+    return any(BACKEND_CHANGE_PATTERN.match(path) for path in changed_files)
 
 
 def is_verify_command(command):

--- a/.codex/hooks/stop_retry.py
+++ b/.codex/hooks/stop_retry.py
@@ -105,9 +105,11 @@ def get_latest_verify_result(transcript_path, turn_id):
             if not is_verify_command(payload.get("command")):
                 continue
 
+            raw_output = payload.get("aggregated_output")
+            output_text = "" if raw_output is None else str(raw_output)
             latest = {
                 "exit_code": payload.get("exit_code"),
-                "output": payload.get("aggregated_output", "")[-4000:],
+                "output": output_text[-4000:],
             }
 
     return latest

--- a/.gitignore
+++ b/.gitignore
@@ -261,7 +261,7 @@ gradle-app.setting
 
 # Codex runtime state
 .codex/state/
-state/
+/state/
 .project
 # JDT-specific (Eclipse Java Development Tools)
 .classpath

--- a/.gitignore
+++ b/.gitignore
@@ -258,6 +258,10 @@ gradle-app.setting
 
 # Eclipse Gradle plugin generated files
 # Eclipse Core
+
+# Codex runtime state
+.codex/state/
+state/
 .project
 # JDT-specific (Eclipse Java Development Tools)
 .classpath


### PR DESCRIPTION
## 🔗 관련 이슈
Closes #125 

---

 ## 변경 내용
  - Codex 작업 종료 시 검증 여부를 점검하는 `.codex/hooks` 기반 검증 hook을 도입했습니다.
  - `PreToolUse` 훅을 추가해 위험한 Bash 명령(`git push --force`, `rm -rf /`, `sudo` 등)을 사전에 차단하도록 구성했습니다.
  - `Stop` 훅을 추가해 백엔드 관련 스테이징 변경이 있을 경우 `bash scripts/verify.sh` 실행 여부와 결과를 확인하도록 구성했습니다.
  - `Stop` 훅은 현재 턴 transcript를 읽어 `scripts/verify.sh` 실행 여부, 성공/실패, retry count를 판단하도록 구현했습니다.
  - 검증 미실행 시에는 verify 실행을 유도하고, 실패 시에는 retry count를 누적하며 최대 3회까지 재시도를 안내하도록 구성했습니다.
  - hook 실행 중 생성되는 runtime 상태 파일은 `.gitignore`로 제외하도록 정리했습니다.

  ---

  ## 변경 이유
  - 기존에는 Codex 작업 종료 전에 검증 실행 여부를 강제하거나 확인하는 자동화 장치가 없었습니다.
  - 그 결과 `scripts/verify.sh`를 실행하지 않은 채 작업이 종료될 가능성이 있었고, 검증 실패 시에도 반복 흐름을 일관되게 유도하기 어려웠습니다.
  - 이번 변경은 저장소의 검증 규칙을 Codex 작업 흐름에 직접 연결해, 백엔드 변경 시 최소한의 검증 루프를 자동으로 유도하기 위해 필요했습니다.
  - 또한 위험한 명령을 사전에 차단해 로컬 작업 안정성을 높이기 위한 목적도 있습니다.

  ---

  ## 테스트
  - [x] 로컬 테스트 완료
  - [x] 주요 시나리오 검증 완료

  ---

  ## 체크리스트
  - [x] self review 완료
  - [x] 불필요한 코드 제거 완료
  - [x] 네이밍 / 컨벤션 확인 완료

  ---
  ## 참고 사항

  - `stop_retry.py`의 transcript 판별 방식과 retry 정책을 중점적으로 봐주시면 좋겠습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 위험한 셸 명령(강제 푸시, 파괴적 삭제, sudo 등)을 감지해 실행을 차단하는 명령 검증 기능 추가
  * 백엔드 관련 변경사항에 대해 자동 검증을 요구하고, 검증 결과에 따라 재시도/차단하는 워크플로우 도입

* **잡일(Chore)**
  * 런타임 상태 파일을 무시하도록 버전 관리 설정 업데이트
<!-- end of auto-generated comment: release notes by coderabbit.ai -->