### PR TITLE
[#139] 통합 테스트 조건부 실행 및 requires-infra 태그 분리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -202,6 +202,10 @@ tasks.jacocoTestCoverageVerification {
 
 tasks.named('test') {
     useJUnitPlatform {
+        def include = providers.systemProperty("includeTags").orNull
+        if (include) {
+            includeTags include.split(',')
+        }
         def exclude = providers.systemProperty("excludeTags").orNull
         if (exclude) {
             excludeTags exclude.split(',')

--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -18,6 +18,20 @@
 
 다른 방식의 검증은 사용하지 않는다.
 
+`./scripts/verify.sh`의 기본 동작은 단위 테스트 우선이다.
+
+* 기본: `@Tag("integration")`, `@Tag("requires-infra")` 테스트를 제외하고 빠르게 실행한다
+* 조건부 추가 실행: 스테이징된 변경에 통합 테스트 관련 파일이 포함되면 `integration` 테스트를 추가 실행하되, `requires-infra`는 계속 제외한다
+
+통합 테스트 관련 파일은 아래를 기준으로 판단한다:
+
+* `src/test/java/**/integration/**`
+* `IntegrationSupportTest`를 직접 수정한 경우
+* `AsyncTestConfig`를 수정한 경우
+* 스테이징된 테스트 클래스가 `IntegrationSupportTest`를 상속하거나 `@Tag("integration")`를 선언한 경우
+
+`requires-infra`는 Redis, MQ처럼 별도 실행 인프라가 필요한 테스트를 위한 태그다.
+
 ---
 
 ## 실행 규칙
@@ -55,7 +69,8 @@ You MUST follow these rules:
 다음 조건을 모두 만족해야 작업을 종료할 수 있다:
 
 * `./scripts/verify.sh`가 exit code 0 반환
-* 모든 단위 테스트가 통과 상태 (통합 테스트 제외)
+* 기본 단위 테스트가 통과 상태
+* 통합 테스트 관련 변경이 있으면 `requires-infra`를 제외한 통합 테스트까지 통과 상태
 * FAIL 메시지가 없음
 
 ---

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -1,5 +1,38 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
+
+is_backend_related_change() {
+  local file="$1"
+  [[ "$file" =~ ^(src/|build\.gradle|build\.gradle\.kts|settings\.gradle|settings\.gradle\.kts|gradle/|gradlew|gradlew\.bat) ]]
+}
+
+has_staged_file() {
+  local file="$1"
+  git cat-file -e ":$file" 2>/dev/null
+}
+
+is_integration_test_change() {
+  local file="$1"
+
+  if [[ "$file" == "src/test/java/com/carumuch/capstone/support/IntegrationSupportTest.java" ]] || \
+     [[ "$file" == "src/test/java/com/carumuch/capstone/support/config/AsyncTestConfig.java" ]]; then
+    return 0
+  fi
+
+  if [[ ! "$file" =~ ^src/test/java/.*\.java$ ]]; then
+    return 1
+  fi
+
+  if [[ "$file" =~ /integration/ ]]; then
+    return 0
+  fi
+
+  if ! has_staged_file "$file"; then
+    return 1
+  fi
+
+  git show ":$file" | grep -qE 'extends[[:space:]]+IntegrationSupportTest|@Tag\("integration"\)'
+}
 
 CHANGED_FILES="$(git diff --cached --name-only || true)"
 
@@ -8,7 +41,22 @@ PARTIAL=$(comm -12 \
     <(git diff --cached --name-only | sort -u) \
     <(git diff --name-only | sort -u))
 
-if echo "$CHANGED_FILES" | grep -qE '^(src/|build\.gradle|build\.gradle\.kts|settings\.gradle|settings\.gradle\.kts|gradle/|gradlew|gradlew\.bat)'; then
+RUN_INTEGRATION_TESTS=false
+RUN_BACKEND_VERIFICATION=false
+
+while IFS= read -r changed_file; do
+  [ -z "$changed_file" ] && continue
+
+  if is_backend_related_change "$changed_file"; then
+    RUN_BACKEND_VERIFICATION=true
+  fi
+
+  if is_integration_test_change "$changed_file"; then
+    RUN_INTEGRATION_TESTS=true
+  fi
+done <<< "$CHANGED_FILES"
+
+if [ "$RUN_BACKEND_VERIFICATION" = true ]; then
 
   # 부분 스테이징 경고
   if [ -n "$PARTIAL" ]; then
@@ -17,11 +65,15 @@ if echo "$CHANGED_FILES" | grep -qE '^(src/|build\.gradle|build\.gradle\.kts|set
     fi
 
   # 스프링 테스트 (통합 테스트 제외)
-  echo "[verify] test (exclude integration)"
-  ./gradlew test -DexcludeTags=integration || { echo "[fail] test"; exit 1; }
+  echo "[verify] test (exclude integration, requires-infra)"
+  ./gradlew test -DexcludeTags=integration,requires-infra || { echo "[fail] test"; exit 1; }
+
+  if [ "$RUN_INTEGRATION_TESTS" = true ]; then
+    echo "[verify] test (include integration, exclude requires-infra)"
+    ./gradlew test -DincludeTags=integration -DexcludeTags=requires-infra || { echo "[fail] integration test"; exit 1; }
+  fi
 
   echo "[verify] SUCCESS"
 else
   echo "[skip] no backend-related changes"
 fi
-

--- a/src/test/java/com/carumuch/capstone/identity/integration/AccountRecoveryServiceIntegrationTest.java
+++ b/src/test/java/com/carumuch/capstone/identity/integration/AccountRecoveryServiceIntegrationTest.java
@@ -26,10 +26,12 @@ import com.carumuch.capstone.common.exception.UnauthorizedException;
 import com.carumuch.capstone.common.infrastructure.mail.MailSender;
 import com.carumuch.capstone.common.infrastructure.mail.TemplateRenderer;
 import com.carumuch.capstone.support.IntegrationSupportTest;
+import com.carumuch.capstone.support.RequiresInfraTest;
 import com.carumuch.capstone.support.fixture.UserFixture;
 import com.carumuch.capstone.identity.domain.user.User;
 import com.carumuch.capstone.identity.domain.user.UserRepository;
 
+@RequiresInfraTest
 public class AccountRecoveryServiceIntegrationTest extends IntegrationSupportTest {
 
 	@Autowired AccountRecoveryService accountRecoveryService;

--- a/src/test/java/com/carumuch/capstone/identity/integration/AuthServiceIntegrationTest.java
+++ b/src/test/java/com/carumuch/capstone/identity/integration/AuthServiceIntegrationTest.java
@@ -31,10 +31,18 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 @RequiresInfraTest
 class AuthServiceIntegrationTest extends IntegrationSupportTest {
 
-	@Autowired AuthService authService;
-	@Autowired UserRepository userRepository;
-	@Autowired BCryptPasswordEncoder bCryptPasswordEncoder;
-	@Autowired RefreshTokenStore refreshTokenStore;
+	@Autowired
+	AuthService authService;
+
+	@Autowired
+	UserRepository userRepository;
+
+	@Autowired
+	BCryptPasswordEncoder bCryptPasswordEncoder;
+
+	@Autowired
+	RefreshTokenStore refreshTokenStore;
+
 	@Autowired
 	JwtTokenProvider jwtTokenProvider;
 

--- a/src/test/java/com/carumuch/capstone/identity/integration/AuthServiceIntegrationTest.java
+++ b/src/test/java/com/carumuch/capstone/identity/integration/AuthServiceIntegrationTest.java
@@ -12,6 +12,7 @@ import com.carumuch.capstone.identity.domain.user.User;
 import com.carumuch.capstone.identity.domain.user.UserRepository;
 import com.carumuch.capstone.support.fixture.UserFixture;
 import com.carumuch.capstone.support.IntegrationSupportTest;
+import com.carumuch.capstone.support.RequiresInfraTest;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -27,6 +28,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 
+@RequiresInfraTest
 class AuthServiceIntegrationTest extends IntegrationSupportTest {
 
 	@Autowired AuthService authService;

--- a/src/test/java/com/carumuch/capstone/support/RequiresInfraTest.java
+++ b/src/test/java/com/carumuch/capstone/support/RequiresInfraTest.java
@@ -1,0 +1,14 @@
+package com.carumuch.capstone.support;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.Tag;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Tag("requires-infra")
+public @interface RequiresInfraTest {
+}


### PR DESCRIPTION
 ## 🔗 관련 이슈
  Refs #139

  ---

  ## 변경 내용
  - `scripts/verify.sh`에서 테스트 실행 정책을 분리했습니다.
  - 기본 검증에서는 `integration`, `requires-infra` 태그 테스트를 제외하고 빠르게 실행하도록 변경했습니다.
  - 통합 테스트 관련 파일이 변경된 경우에만 `integration` 테스트를 추가 실행하되, `requires-infra`는 계속 제외하도록 구성했습니다.
  - `@Tag("requires-infra")` 문자열 중복을 없애기 위해 `@RequiresInfraTest` 커스텀 애노테이션을 추가했습니다.
  - Redis 등 별도 인프라 의존 통합 테스트에 `@RequiresInfraTest`를 적용했습니다.

  ---

  ## 변경 이유
  - 기존 `verify.sh`는 통합 테스트를 항상 제외해 빠르다는 장점이 있었지만, 통합 테스트 자체를 추가하거나 수정하는 경우에도 해당 테스트가 자동 검증되지 않는 문제가 있었습니다.
  - Redis처럼 실행 환경에 의존하는 테스트는 일반 통합 테스트와 별도로 분리할 필요가 있었습니다.
  - 태그 문자열을 테스트 클래스마다 직접 작성하기보다 의미 있는 커스텀 애노테이션으로 추상화하는 편이 유지보수에 더 적절하다고 판단했습니다.

  ---

  ## 테스트
  - [x] 로컬 테스트 완료
  - [x] 주요 시나리오 검증 완료
  - [x] 테스트 코드 추가/수정 완료

  ---

  ## 체크리스트
  - [x] self review 완료
  - [x] 불필요한 코드 제거 완료
  - [x] 네이밍 / 컨벤션 확인 완료

  ---
  ## 참고 사항

  - 현재 `requires-infra`는 Redis 의존 통합 테스트 2개에 우선 적용했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **Tests**
  * 테스트 선택 필터링이 개선되어 특정 테스트만 선택적으로 실행할 수 있습니다.
  * 인프라가 필요한 테스트가 명확하게 분류되고 관리되도록 정렬되었습니다.

* **Chores**
  * 검증 프로세스가 변경된 파일을 자동으로 감지하여 필요한 테스트만 실행하도록 최적화되었습니다.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/carumuch/carumuch-backend/pull/140)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->