### PR TITLE
[#147]TiDD 기반 에이전트 개발 하네스 구축

### DIFF
--- a/.codex/rules/default.rules
+++ b/.codex/rules/default.rules
@@ -31,6 +31,22 @@ prefix_rule(
   ],
 )
 
+# cmux를 통한 멀티 에이전트 병렬처리 허용
+prefix_rule(
+  pattern = ["cmux"],
+  decision = "allow",
+  justification = "cmux 워크스페이스 제어 명령은 반복 승인 없이 사용합니다.",
+  match = [
+    "cmux current-workspace",
+    "cmux tree --workspace workspace:1",
+    "cmux new-pane --direction right",
+    "cmux send --surface surface:2 ls",
+    "cmux read-screen --surface surface:2 --lines 50",
+    "cmux notify --title done --body ok",
+  ],
+  not_match = [],
+)
+
 # --------------------------------------------------
 #                       확인
 # --------------------------------------------------

--- a/.codex/skills/carumuch-dev-cycle/SKILL.md
+++ b/.codex/skills/carumuch-dev-cycle/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: dev-cycle
+name: carumuch-dev-cycle
 description: Use when executing backend code changes in this repository and you need a repeatable implementer-verifier-reviewer workflow with bounded retry attempts
 ---
 

--- a/.codex/skills/carumuch-ticket-generator/SKILL.md
+++ b/.codex/skills/carumuch-ticket-generator/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: ticket-generator
+name: carumuch-ticket-generator
 description: Use when the user provides a GitHub issue number in this repository and wants a TiDD ticket created from `docs/tickets/TEMPLATE.md`
 ---
 

--- a/.codex/skills/carumuch-tidd-finalizer/SKILL.md
+++ b/.codex/skills/carumuch-tidd-finalizer/SKILL.md
@@ -15,7 +15,8 @@ description: Use when a user has chosen agent A, agent B, or cancel after a TiDD
 2. 핵심 티켓 브랜치 worktree에서 검증 실행
 3. `agent-a`, `agent-b` pane 정리
 4. agent worktree 정리
-5. 최종 보고 출력
+5. 성공적으로 마무리되면 핵심 티켓 브랜치 worktree도 정리
+6. 최종 보고 출력
 
 `취소`를 선택하면 병합과 테스트는 수행하지 않고, TiDD가 만든 브랜치/worktree/pane 자원을 전부 정리합니다.
 
@@ -47,9 +48,13 @@ description: Use when a user has chosen agent A, agent B, or cancel after a TiDD
 
 - `agent-a`, `agent-b` pane은 닫습니다.
 - `agent-a/<ticket-id>`, `agent-b/<ticket-id>` worktree는 정리 대상으로 봅니다.
-- 기본 finalize에서는 핵심 티켓 브랜치 worktree를 남깁니다.
+- `A` 또는 `B` 경로에서 merge가 성공하면 `agent-a/<ticket-id>`, `agent-b/<ticket-id>` worktree는 dirty 여부와 관계없이 강제 정리합니다.
+- `A` 또는 `B` 경로에서 merge가 성공하면 `agent-a/<ticket-id>`, `agent-b/<ticket-id>` 브랜치도 함께 삭제합니다.
+- 기본 finalize에서는 merge와 verify가 모두 성공하고 핵심 티켓 worktree가 clean하면 그 worktree도 정리합니다.
+- 핵심 티켓 브랜치 자체는 삭제하지 않으며, 사용자가 메인 worktree에서 직접 `git checkout <target-branch>` 할 수 있게 만드는 것이 목적입니다.
 - 현재 사용자의 메인 pane과 현재 worktree는 유지합니다.
-- dirty 상태인 worktree는 강제로 삭제하지 않고, final report에 남깁니다.
+- merge가 실패하면 agent worktree와 agent branch는 자동 삭제하지 않고, final report에 남깁니다.
+- verify가 실패했거나 dirty 상태인 핵심 티켓 worktree는 강제로 삭제하지 않고, final report에 남깁니다.
 - `취소`를 선택하면 아래 자원을 모두 정리 대상으로 봅니다.
   - 핵심 티켓 브랜치 worktree
   - `agent-a/<ticket-id>` worktree
@@ -68,9 +73,11 @@ description: Use when a user has chosen agent A, agent B, or cancel after a TiDD
 5. `A` 또는 `B`면 핵심 티켓 브랜치 worktree에서 선택한 agent 브랜치를 병합합니다.
 6. `A` 또는 `B`면 핵심 티켓 브랜치 worktree에서 `bash scripts/verify.sh`를 실행합니다.
 7. `agent-a`, `agent-b` pane을 닫습니다.
-8. `A` 또는 `B`면 agent worktree를 정리합니다.
-9. `취소`면 티켓 worktree, agent worktree, 관련 브랜치를 모두 정리합니다.
-10. 병합 결과, 검증 결과, pane 정리 결과, worktree/브랜치 정리 결과를 최종 보고로 출력합니다.
+8. `A` 또는 `B`면 merge가 성공했을 때 agent worktree를 강제 정리합니다.
+9. `A` 또는 `B`면 merge가 성공했을 때 agent branch도 정리합니다.
+10. `A` 또는 `B`면 merge와 verify가 모두 성공했을 때 핵심 티켓 브랜치 worktree도 정리해 메인 worktree에서 수동 checkout 가능 상태를 만듭니다.
+11. `취소`면 티켓 worktree, agent worktree, 관련 브랜치를 모두 정리합니다.
+12. 병합 결과, 검증 결과, pane 정리 결과, worktree/브랜치 정리 결과를 최종 보고로 출력합니다.
 
 ## Command
 
@@ -94,4 +101,5 @@ bash .codex/skills/carumuch-tidd-finalizer/scripts/finalize-tidd.sh 144 cancel
 - 병합은 핵심 티켓 브랜치 worktree 내부에서만 수행합니다.
 - 테스트 실패 시에도 pane/worktree 정리 결과는 final report에 함께 남깁니다.
 - verify 실패를 숨기지 않습니다.
+- 성공적으로 finalize되더라도 메인 worktree에서 target branch를 자동 checkout 하지는 않습니다.
 - `취소` 경로는 TiDD가 만든 브랜치/worktree/pane 자원을 제거하지만, 현재 사용자의 작업 브랜치와 현재 worktree는 건드리지 않습니다.

--- a/.codex/skills/carumuch-tidd-finalizer/SKILL.md
+++ b/.codex/skills/carumuch-tidd-finalizer/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: carumuch-tidd-finalizer
+description: Use when a user has chosen agent A, agent B, or cancel after a TiDD orchestrator run and wants to finalize the ticket resources safely
+---
+
+# TiDD Finalizer
+
+## Overview
+
+이 스킬은 `carumuch-tidd-orchestrator` 실행 이후 사용자가 `A`, `B`, 또는 `취소`를 선택했을 때 마무리 작업을 수행하는 절차입니다.
+
+수행 순서는 아래와 같습니다.
+
+1. 선택한 agent 브랜치를 핵심 티켓 브랜치에 병합
+2. 핵심 티켓 브랜치 worktree에서 검증 실행
+3. `agent-a`, `agent-b` pane 정리
+4. agent worktree 정리
+5. 최종 보고 출력
+
+`취소`를 선택하면 병합과 테스트는 수행하지 않고, TiDD가 만든 브랜치/worktree/pane 자원을 전부 정리합니다.
+
+현재 사용자의 메인 pane 브랜치와 worktree는 변경하지 않습니다.
+
+## When to Use
+
+- `carumuch-tidd-orchestrator`로 `agent-a`, `agent-b` 비교 작업을 마친 뒤 하나를 채택할 때
+- 선택한 결과만 핵심 티켓 브랜치에 반영하고 싶을 때
+- merge 이후 테스트, pane 정리, worktree 정리를 한 번에 마무리하고 싶을 때
+- TiDD 작업 자체를 폐기하고 관련 자원을 모두 정리하고 싶을 때
+
+사용하지 않을 때:
+
+- 아직 어느 agent를 채택할지 결정하지 않은 경우
+- 선택한 agent worktree에 미커밋 변경이 남아 있는 경우
+- 핵심 티켓 브랜치가 아니라 현재 사용자 브랜치까지 바로 합치고 싶은 경우
+
+## Merge Contract
+
+- 병합 대상은 `선택한 agent 브랜치 -> 핵심 티켓 브랜치`까지만입니다.
+- 현재 사용자의 메인 브랜치에는 자동 병합하지 않습니다.
+- 핵심 티켓 브랜치는 `docs/tickets/TICKET-<ticket-id>.md`의 `원본 브랜치`를 사용합니다.
+- 핵심 티켓 브랜치가 없으면 이 스킬은 새로 생성하지 않고 실패 처리합니다.
+- 선택한 agent worktree 또는 핵심 티켓 worktree가 dirty하면 자동 병합하지 않습니다.
+- `취소`를 선택하면 병합과 테스트를 수행하지 않습니다.
+
+## Cleanup Contract
+
+- `agent-a`, `agent-b` pane은 닫습니다.
+- `agent-a/<ticket-id>`, `agent-b/<ticket-id>` worktree는 정리 대상으로 봅니다.
+- 기본 finalize에서는 핵심 티켓 브랜치 worktree를 남깁니다.
+- 현재 사용자의 메인 pane과 현재 worktree는 유지합니다.
+- dirty 상태인 worktree는 강제로 삭제하지 않고, final report에 남깁니다.
+- `취소`를 선택하면 아래 자원을 모두 정리 대상으로 봅니다.
+  - 핵심 티켓 브랜치 worktree
+  - `agent-a/<ticket-id>` worktree
+  - `agent-b/<ticket-id>` worktree
+  - 핵심 티켓 브랜치
+  - `agent-a/<ticket-id>` 브랜치
+  - `agent-b/<ticket-id>` 브랜치
+- `취소` 경로는 사용자가 명시적으로 요청한 정리 작업이므로, 위 TiDD 자원에 한해 강제 정리를 허용합니다.
+
+## Workflow
+
+1. `docs/tickets/TICKET-<ticket-id>.md`를 읽고 `원본 브랜치`를 확인합니다.
+2. 사용자가 선택한 값 `A`, `B`, `취소`를 해석합니다.
+3. `A` 또는 `B`면 핵심 티켓 브랜치 worktree와 선택한 agent worktree가 모두 존재하는지 확인합니다.
+4. `A` 또는 `B`면 선택한 agent worktree와 핵심 티켓 worktree가 clean 상태인지 확인합니다.
+5. `A` 또는 `B`면 핵심 티켓 브랜치 worktree에서 선택한 agent 브랜치를 병합합니다.
+6. `A` 또는 `B`면 핵심 티켓 브랜치 worktree에서 `bash scripts/verify.sh`를 실행합니다.
+7. `agent-a`, `agent-b` pane을 닫습니다.
+8. `A` 또는 `B`면 agent worktree를 정리합니다.
+9. `취소`면 티켓 worktree, agent worktree, 관련 브랜치를 모두 정리합니다.
+10. 병합 결과, 검증 결과, pane 정리 결과, worktree/브랜치 정리 결과를 최종 보고로 출력합니다.
+
+## Command
+
+저장소 루트 기준 실행 예시는 아래와 같습니다.
+
+```bash
+bash .codex/skills/tidd-finalizer/scripts/finalize-tidd.sh 144 A
+bash .codex/skills/tidd-finalizer/scripts/finalize-tidd.sh 144 B
+bash .codex/skills/tidd-finalizer/scripts/finalize-tidd.sh 144 cancel
+```
+
+첫 번째 인자는 ticket id, 두 번째 인자는 선택 결과입니다.
+
+- `A`, `a`, `agent-a` 모두 `agent-a`로 처리합니다.
+- `B`, `b`, `agent-b` 모두 `agent-b`로 처리합니다.
+- `cancel`, `취소`, `c`는 취소 정리 경로로 처리합니다.
+
+## Notes
+
+- 이 스킬은 현재 사용자 브랜치를 checkout 하지 않습니다.
+- 병합은 핵심 티켓 브랜치 worktree 내부에서만 수행합니다.
+- 테스트 실패 시에도 pane/worktree 정리 결과는 final report에 함께 남깁니다.
+- verify 실패를 숨기지 않습니다.
+- `취소` 경로는 TiDD가 만든 브랜치/worktree/pane 자원을 제거하지만, 현재 사용자의 작업 브랜치와 현재 worktree는 건드리지 않습니다.

--- a/.codex/skills/carumuch-tidd-finalizer/SKILL.md
+++ b/.codex/skills/carumuch-tidd-finalizer/SKILL.md
@@ -77,9 +77,9 @@ description: Use when a user has chosen agent A, agent B, or cancel after a TiDD
 저장소 루트 기준 실행 예시는 아래와 같습니다.
 
 ```bash
-bash .codex/skills/tidd-finalizer/scripts/finalize-tidd.sh 144 A
-bash .codex/skills/tidd-finalizer/scripts/finalize-tidd.sh 144 B
-bash .codex/skills/tidd-finalizer/scripts/finalize-tidd.sh 144 cancel
+bash .codex/skills/carumuch-tidd-finalizer/scripts/finalize-tidd.sh 144 A
+bash .codex/skills/carumuch-tidd-finalizer/scripts/finalize-tidd.sh 144 B
+bash .codex/skills/carumuch-tidd-finalizer/scripts/finalize-tidd.sh 144 cancel
 ```
 
 첫 번째 인자는 ticket id, 두 번째 인자는 선택 결과입니다.

--- a/.codex/skills/carumuch-tidd-finalizer/scripts/finalize-tidd.sh
+++ b/.codex/skills/carumuch-tidd-finalizer/scripts/finalize-tidd.sh
@@ -1,0 +1,262 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ticket_id="${1:-}"
+selection_raw="${2:-}"
+
+if [[ -z "$ticket_id" || -z "$selection_raw" ]]; then
+  echo "usage: $0 <ticket-id> <A|B|agent-a|agent-b|cancel>" >&2
+  exit 1
+fi
+
+case "${selection_raw,,}" in
+  a|agent-a)
+    selected_agent="agent-a"
+    selected_branch="agent-a/$ticket_id"
+    selected_title="A"
+    ;;
+  b|agent-b)
+    selected_agent="agent-b"
+    selected_branch="agent-b/$ticket_id"
+    selected_title="B"
+    ;;
+  c|cancel|취소)
+    selected_agent="cancel"
+    selected_branch=""
+    selected_title="CANCEL"
+    ;;
+  *)
+    echo "invalid selection: $selection_raw" >&2
+    exit 1
+    ;;
+esac
+
+workspace="${CMUX_WORKSPACE_ID:-$(cmux current-workspace)}"
+repo_root="$(git rev-parse --show-toplevel)"
+repo_name="$(basename "$repo_root")"
+parent_dir="$(dirname "$repo_root")"
+main_surface="${CMUX_SURFACE_ID:-}"
+ticket_file="$repo_root/docs/tickets/TICKET-$ticket_id.md"
+ticket_branch_path="$parent_dir/${repo_name}-ticket-${ticket_id//\//-}"
+agent_a_path="$parent_dir/${repo_name}-agent-a-${ticket_id//\//-}"
+agent_b_path="$parent_dir/${repo_name}-agent-b-${ticket_id//\//-}"
+
+require_bin() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+parse_original_branch() {
+  awk -F'`' '/- 원본 브랜치:/ { print $2; exit }' "$ticket_file"
+}
+
+surface_by_title() {
+  local title="$1"
+  cmux tree --workspace "$workspace" \
+    | awk -v title="$title" '$0 ~ "\"" title "\"" {for (i = 1; i <= NF; i++) if ($i ~ /^surface:/) {print $i; exit}}'
+}
+
+close_if_present() {
+  local title="$1"
+  local surface
+  surface="$(surface_by_title "$title" || true)"
+  if [[ -n "$surface" ]]; then
+    cmux close-surface --workspace "$workspace" --surface "$surface" >/dev/null
+    printf 'closed %s (%s)\n' "$title" "$surface"
+  else
+    printf 'not-found %s\n' "$title"
+  fi
+}
+
+ensure_registered_worktree() {
+  local path="$1"
+  if ! git worktree list --porcelain | awk -v path="$path" '
+      $1 == "worktree" && $2 == path { found = 1 }
+      END { exit(found ? 0 : 1) }
+    '; then
+    echo "worktree not registered: $path" >&2
+    exit 1
+  fi
+}
+
+worktree_is_clean() {
+  local path="$1"
+  git -C "$path" diff --quiet --ignore-submodules HEAD -- \
+    && git -C "$path" diff --quiet --ignore-submodules --cached --
+}
+
+remove_worktree_if_clean() {
+  local path="$1"
+  local label="$2"
+
+  if [[ ! -d "$path" ]]; then
+    printf '%s: not-found\n' "$label"
+    return 0
+  fi
+
+  if ! git worktree list --porcelain | awk -v path="$path" '
+      $1 == "worktree" && $2 == path { found = 1 }
+      END { exit(found ? 0 : 1) }
+    '; then
+    printf '%s: not-registered\n' "$label"
+    return 0
+  fi
+
+  if worktree_is_clean "$path"; then
+    git worktree remove "$path" >/dev/null
+    printf '%s: removed\n' "$label"
+  else
+    printf '%s: skipped-dirty\n' "$label"
+  fi
+}
+
+remove_worktree_force_if_registered() {
+  local path="$1"
+  local label="$2"
+
+  if [[ ! -d "$path" ]]; then
+    printf '%s: not-found\n' "$label"
+    return 0
+  fi
+
+  if ! git worktree list --porcelain | awk -v path="$path" '
+      $1 == "worktree" && $2 == path { found = 1 }
+      END { exit(found ? 0 : 1) }
+    '; then
+    printf '%s: not-registered\n' "$label"
+    return 0
+  fi
+
+  git worktree remove --force "$path" >/dev/null
+  printf '%s: force-removed\n' "$label"
+}
+
+delete_branch_if_present() {
+  local branch="$1"
+  local label="$2"
+
+  if git show-ref --verify --quiet "refs/heads/$branch"; then
+    git branch -D "$branch" >/dev/null
+    printf '%s: deleted\n' "$label"
+  else
+    printf '%s: not-found\n' "$label"
+  fi
+}
+
+require_bin cmux
+require_bin git
+require_bin bash
+
+if [[ ! -f "$ticket_file" ]]; then
+  echo "ticket file not found: $ticket_file" >&2
+  exit 1
+fi
+
+ticket_branch="$(parse_original_branch)"
+if [[ -z "$ticket_branch" ]]; then
+  echo "original branch not found in ticket: $ticket_file" >&2
+  exit 1
+fi
+
+merge_status="SKIP"
+verify_status="SKIP"
+verify_output="not-run"
+
+if [[ "$selected_agent" != "cancel" ]]; then
+  case "$selected_agent" in
+    agent-a)
+      selected_path="$agent_a_path"
+      ;;
+    agent-b)
+      selected_path="$agent_b_path"
+      ;;
+  esac
+
+  ensure_registered_worktree "$ticket_branch_path"
+  ensure_registered_worktree "$selected_path"
+
+  if ! worktree_is_clean "$ticket_branch_path"; then
+    echo "ticket worktree is dirty: $ticket_branch_path" >&2
+    exit 1
+  fi
+
+  if ! worktree_is_clean "$selected_path"; then
+    echo "selected agent worktree is dirty: $selected_path" >&2
+    exit 1
+  fi
+
+  merge_status="PASS"
+  verify_status="PASS"
+
+  if ! git -C "$ticket_branch_path" merge --no-ff "$selected_branch" -m "merge: apply $selected_branch into $ticket_branch for TICKET-$ticket_id" >/tmp/tidd-finalizer-merge.log 2>&1; then
+    merge_status="FAIL"
+  fi
+
+  if [[ "$merge_status" == "PASS" ]]; then
+    if ! verify_output="$(cd "$ticket_branch_path" && bash scripts/verify.sh 2>&1)"; then
+      verify_status="FAIL"
+    fi
+  else
+    verify_status="SKIP"
+    verify_output="merge failed"
+  fi
+fi
+
+pane_cleanup_output="$(
+  {
+    close_if_present "agent-a"
+    close_if_present "agent-b"
+  } 2>&1
+)"
+
+if [[ "$selected_agent" == "cancel" ]]; then
+  worktree_cleanup_output="$(
+    {
+      remove_worktree_force_if_registered "$agent_a_path" "agent-a worktree"
+      remove_worktree_force_if_registered "$agent_b_path" "agent-b worktree"
+      remove_worktree_force_if_registered "$ticket_branch_path" "ticket worktree"
+    } 2>&1
+  )"
+
+  branch_cleanup_output="$(
+    {
+      delete_branch_if_present "agent-a/$ticket_id" "agent-a branch"
+      delete_branch_if_present "agent-b/$ticket_id" "agent-b branch"
+      delete_branch_if_present "$ticket_branch" "ticket branch"
+    } 2>&1
+  )"
+else
+  worktree_cleanup_output="$(
+    {
+      remove_worktree_if_clean "$agent_a_path" "agent-a worktree"
+      remove_worktree_if_clean "$agent_b_path" "agent-b worktree"
+    } 2>&1
+  )"
+  branch_cleanup_output="branch cleanup skipped"
+fi
+
+printf '\n== TiDD Final Report ==\n'
+printf '선택: %s' "$selected_title"
+if [[ -n "$selected_branch" ]]; then
+  printf ' (%s)\n' "$selected_branch"
+else
+  printf '\n'
+fi
+printf '핵심 티켓 브랜치: %s\n' "$ticket_branch"
+printf '병합 결과: %s\n' "$merge_status"
+printf '테스트 결과: %s\n' "$verify_status"
+printf '\n[Pane 정리]\n%s\n' "$pane_cleanup_output"
+printf '\n[Worktree 정리]\n%s\n' "$worktree_cleanup_output"
+printf '\n[브랜치 정리]\n%s\n' "$branch_cleanup_output"
+printf '\n[남은 작업 경로]\n'
+printf 'ticket worktree: %s\n' "$ticket_branch_path"
+printf 'current worktree: %s\n' "$repo_root"
+printf '\n[검증 출력]\n%s\n' "$verify_output"
+
+cmux notify \
+  --workspace "$workspace" \
+  --surface "$main_surface" \
+  --title "tidd-finalizer complete" \
+  --body "selected=${selected_branch:-cancel} merge=$merge_status verify=$verify_status" >/dev/null || true

--- a/.codex/skills/carumuch-tidd-finalizer/scripts/finalize-tidd.sh
+++ b/.codex/skills/carumuch-tidd-finalizer/scripts/finalize-tidd.sh
@@ -3,13 +3,14 @@ set -euo pipefail
 
 ticket_id="${1:-}"
 selection_raw="${2:-}"
+selection_normalized="$(printf '%s' "$selection_raw" | tr '[:upper:]' '[:lower:]')"
 
 if [[ -z "$ticket_id" || -z "$selection_raw" ]]; then
   echo "usage: $0 <ticket-id> <A|B|agent-a|agent-b|cancel>" >&2
   exit 1
 fi
 
-case "${selection_raw,,}" in
+case "$selection_normalized" in
   a|agent-a)
     selected_agent="agent-a"
     selected_branch="agent-a/$ticket_id"
@@ -83,8 +84,7 @@ ensure_registered_worktree() {
 
 worktree_is_clean() {
   local path="$1"
-  git -C "$path" diff --quiet --ignore-submodules HEAD -- \
-    && git -C "$path" diff --quiet --ignore-submodules --cached --
+  [[ -z "$(git -C "$path" status --short --untracked-files=normal)" ]]
 }
 
 remove_worktree_if_clean() {
@@ -227,14 +227,47 @@ if [[ "$selected_agent" == "cancel" ]]; then
       delete_branch_if_present "$ticket_branch" "ticket branch"
     } 2>&1
   )"
+  next_step_output="current worktree는 유지되며, TiDD 자원만 정리되었습니다."
 else
-  worktree_cleanup_output="$(
-    {
-      remove_worktree_if_clean "$agent_a_path" "agent-a worktree"
-      remove_worktree_if_clean "$agent_b_path" "agent-b worktree"
-    } 2>&1
-  )"
-  branch_cleanup_output="branch cleanup skipped"
+  ticket_worktree_cleanup_output="ticket worktree: preserved-for-inspection"
+
+  if [[ "$merge_status" == "PASS" && "$verify_status" == "PASS" ]]; then
+    ticket_worktree_cleanup_output="$(
+      remove_worktree_if_clean "$ticket_branch_path" "ticket worktree" 2>&1
+    )"
+  fi
+
+  if [[ "$merge_status" == "PASS" ]]; then
+    worktree_cleanup_output="$(
+      {
+        remove_worktree_force_if_registered "$agent_a_path" "agent-a worktree"
+        remove_worktree_force_if_registered "$agent_b_path" "agent-b worktree"
+        printf '%s\n' "$ticket_worktree_cleanup_output"
+      } 2>&1
+    )"
+
+    branch_cleanup_output="$(
+      {
+        delete_branch_if_present "agent-a/$ticket_id" "agent-a branch"
+        delete_branch_if_present "agent-b/$ticket_id" "agent-b branch"
+      } 2>&1
+    )"
+  else
+    worktree_cleanup_output="$(
+      {
+        remove_worktree_if_clean "$agent_a_path" "agent-a worktree"
+        remove_worktree_if_clean "$agent_b_path" "agent-b worktree"
+        printf '%s\n' "$ticket_worktree_cleanup_output"
+      } 2>&1
+    )"
+    branch_cleanup_output="branch cleanup skipped (merge failed)"
+  fi
+
+  if [[ "$ticket_worktree_cleanup_output" == "ticket worktree: removed" ]]; then
+    next_step_output="main worktree에서 git checkout $ticket_branch 로 선택 결과를 확인할 수 있습니다."
+  else
+    next_step_output="ticket worktree가 남아 있으면 main worktree에서 git checkout $ticket_branch 가 막힐 수 있습니다. 남은 경로: $ticket_branch_path"
+  fi
 fi
 
 printf '\n== TiDD Final Report ==\n'
@@ -253,6 +286,7 @@ printf '\n[브랜치 정리]\n%s\n' "$branch_cleanup_output"
 printf '\n[남은 작업 경로]\n'
 printf 'ticket worktree: %s\n' "$ticket_branch_path"
 printf 'current worktree: %s\n' "$repo_root"
+printf '\n[다음 단계]\n%s\n' "$next_step_output"
 printf '\n[검증 출력]\n%s\n' "$verify_output"
 
 cmux notify \

--- a/.codex/skills/carumuch-tidd-orchestrator/SKILL.md
+++ b/.codex/skills/carumuch-tidd-orchestrator/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: carumuch-tidd-orchestrator
+description: Use when the user wants a TiDD-style pair of Codex helper panes in the current cmux workspace, each isolated in its own git worktree and branch
+---
+
+# TiDD Orchestrator
+
+## Overview
+
+이 스킬은 현재 `cmux` 워크스페이스에서 TiDD 작업용 보조 pane 2개를 표준 레이아웃으로 띄우는 절차입니다.
+현재 사용자가 작업 중인 브랜치와 worktree는 건드리지 않는 것이 전제입니다.
+
+- 우측 상단: `agent-a`
+- 우측 하단: `agent-b`
+
+각 pane은 같은 작업 디렉터리를 공유하지 않고, 서로 다른 git worktree에서 `codex`를 실행합니다.
+브랜치와 worktree는 아래 형식으로 분리합니다.
+
+- 현재 메인 pane: 사용자의 현재 브랜치 유지
+- 별도 핵심 티켓 브랜치 worktree
+- `agent-a/<ticket-id>`
+- `agent-b/<ticket-id>`
+
+예:
+
+- 현재 메인 pane: `chore/147-agent-parallel-tidd-harness` 유지
+- 핵심 티켓 브랜치 worktree: `chore/144-improve-bodyshop-keyword-search`
+- `agent-a/144`
+- `agent-b/144`
+
+같은 ticket id를 두 agent 모두 공유하되, 시작 전략은 다르게 둡니다.
+
+- `agent-a`: 티켓 범위를 벗어나지 않는 최소 변경 구현
+- `agent-b`: 같은 티켓 범위 안에서 유지보수성까지 고려한 구현
+
+두 agent 모두 실제 개발 절차는 반드시 [carumuch-dev-cycle](/Users/yeongmujo/Desktop/Repository/carumuch-backend/.codex/skills/dev-cycle/SKILL.md)를 따릅니다.
+
+## When to Use
+
+- 사용자가 현재 `cmux` 워크스페이스에 TiDD용 보조 agent 2개를 띄우고 싶을 때
+- 각 agent를 독립 브랜치와 worktree로 분리해서 병렬 작업시키고 싶을 때
+- 같은 `TICKET-<id>.md`를 기준으로 서로 다른 구현 전략을 비교하고 싶을 때
+- 좌측 메인 pane은 유지한 채 우측에 표준 보조 레이아웃을 만들고 싶을 때
+
+사용하지 않을 때:
+
+- 단일 agent만 필요한 경우
+- 기존 우측 pane 레이아웃을 그대로 보존해야 하는 경우
+- `cmux` 없이 일반 셸만 사용하는 경우
+
+## Layout Contract
+
+- 현재 포커스된 메인 pane은 좌측에 유지합니다.
+- 현재 메인 pane의 브랜치와 작업 디렉터리는 변경하지 않습니다.
+- `agent-a`를 먼저 오른쪽에 생성합니다.
+- `agent-a` pane을 기준으로 아래에 `agent-b`를 생성합니다.
+- 마지막에는 메인 pane으로 포커스를 돌립니다.
+
+## Git Isolation Contract
+
+- 현재 사용자가 작업 중인 브랜치와 현재 worktree는 변경하지 않습니다.
+- `docs/tickets/TICKET-<ticket-id>.md`에 적힌 `원본 브랜치`를 핵심 티켓 브랜치로 사용합니다.
+- 핵심 티켓 브랜치가 없으면 `develop`을 기준으로 생성합니다.
+- 핵심 티켓 브랜치는 현재 worktree에 checkout 하지 않고, 별도 worktree로 준비합니다.
+- `agent-a`와 `agent-b`는 핵심 티켓 브랜치에서 직접 작업하지 않습니다.
+- `agent-a`는 `agent-a/<ticket-id>` 브랜치가 연결된 별도 worktree에서 작업합니다.
+- `agent-b`는 `agent-b/<ticket-id>` 브랜치가 연결된 별도 worktree에서 작업합니다.
+- `agent-a/<ticket-id>`, `agent-b/<ticket-id>`는 모두 핵심 티켓 브랜치 기준 커밋으로 생성합니다.
+- 기본 worktree 경로는 메인 저장소의 상위 디렉터리에 아래 형식으로 생성합니다.
+  - `<repo-name>-ticket-<ticket-id>`
+  - `<repo-name>-agent-a-<ticket-id>`
+  - `<repo-name>-agent-b-<ticket-id>`
+- 기존 worktree가 이미 있으면 재사용합니다.
+- 기존 worktree에 미커밋 변경이 있어도 자동 삭제하거나 초기화하지 않습니다.
+
+## Workflow
+
+1. 현재 pane이 메인 좌측 pane으로 남아야 하는지 확인합니다.
+2. `cmux`, `git`, `codex` 명령이 있는지 확인합니다.
+3. `docs/tickets/TICKET-<ticket-id>.md`가 존재하는지 확인합니다.
+4. 티켓에서 `원본 브랜치`를 읽습니다.
+5. 핵심 티켓 브랜치를 현재 worktree와 분리된 별도 worktree로 준비합니다.
+6. `agent-a/<ticket-id>`, `agent-b/<ticket-id>`용 개별 worktree를 핵심 티켓 브랜치 기준으로 준비합니다.
+7. 기존 `agent-a`, `agent-b` pane이 남아 있으면 닫고 표준 레이아웃으로 다시 만듭니다.
+8. `agent-a`, `agent-b` pane을 생성하고 각각 해당 worktree로 이동한 뒤 `codex`를 실행합니다.
+9. 두 agent 모두 같은 `TICKET-<ticket-id>.md`와 `carumuch-dev-cycle`을 읽도록 시작 프롬프트를 보냅니다.
+10. 역할은 아래처럼 분리합니다.
+   - `agent-a`: 최소 변경, 티켓 범위 엄수, 불필요한 리팩터링 금지
+   - `agent-b`: 같은 티켓 범위 안에서 유지보수성 개선 허용
+11. 두 agent가 작업을 마치면 각자 고정 형식으로 아래 두 줄을 출력하게 합니다.
+   - `TIDD_SUMMARY: ...`
+   - `TIDD_RECOMMENDATION: ...`
+12. 메인 pane 스크립트가 위 두 줄을 회수해 최종 요약을 출력합니다.
+13. `cmux tree`와 각 pane의 화면을 읽어 결과를 확인합니다.
+
+## Command
+
+저장소 루트 기준 실행 예시는 아래와 같습니다.
+
+```bash
+bash .codex/skills/tidd-orchestrator/scripts/start-tidd-orchestrator.sh 147
+bash .codex/skills/tidd-orchestrator/scripts/start-tidd-orchestrator.sh 203
+```
+
+인자는 필수이며, 넘긴 ticket id를 그대로 브랜치 suffix로 사용합니다.
+동시에 `docs/tickets/TICKET-<ticket-id>.md`를 기준 티켓으로 사용합니다.
+
+예를 들어 `144`를 넘기고 티켓의 `원본 브랜치`가 `chore/144-improve-bodyshop-keyword-search`라면 아래처럼 맞춥니다.
+
+- 현재 메인 pane: 현재 사용자의 브랜치 그대로 유지
+- 별도 핵심 티켓 브랜치 worktree: `chore/144-improve-bodyshop-keyword-search`
+- `agent-a/144`
+- `agent-b/144`
+
+이때 `chore/144-improve-bodyshop-keyword-search`가 없으면 `develop` 기준으로 생성합니다.
+그리고 두 agent는 각자 별도 worktree에서 작업하지만, 기준점은 모두 이 핵심 티켓 브랜치입니다.
+
+## Agent Strategy
+
+### agent-a
+
+- `TICKET-<id>.md`의 작업 범위를 벗어나지 않습니다.
+- 반드시 `carumuch-dev-cycle`을 사용해 implementer -> verifier -> reviewer 순서를 따릅니다.
+- 최소한의 파일과 최소한의 수정만으로 티켓을 해결합니다.
+- 구조 개선이나 리팩터링은 티켓 달성에 꼭 필요한 경우만 허용합니다.
+- 작업 완료 시 마지막 메시지에 `TIDD_SUMMARY:`와 `TIDD_RECOMMENDATION:`을 한 줄씩 출력합니다.
+
+### agent-b
+
+- 같은 `TICKET-<id>.md`를 기준으로 작업합니다.
+- 반드시 `carumuch-dev-cycle`을 사용해 implementer -> verifier -> reviewer 순서를 따릅니다.
+- 기능 구현은 동일하게 달성하되, 유지보수성을 높이는 방향을 우선합니다.
+- 네이밍, 계층 책임, 테스트 구조, repository 분리처럼 장기 유지에 도움이 되는 개선을 허용합니다.
+- 단, 티켓 범위를 벗어나는 기능 추가는 금지합니다.
+- 작업 완료 시 마지막 메시지에 `TIDD_SUMMARY:`와 `TIDD_RECOMMENDATION:`을 한 줄씩 출력합니다.
+
+## Notes
+
+- 이 스킬은 우측 보조 pane 2개만 다룹니다.
+- 메인 pane의 기존 작업 디렉터리와 프로세스는 건드리지 않습니다.
+- 메인 pane의 현재 브랜치를 다른 티켓 브랜치로 checkout 하면 안 됩니다.
+- 부분적으로만 남은 stale pane이 있으면 정리 후 다시 생성합니다.
+- worktree 생성에 실패하면 pane 생성 전에 중단하는 것이 원칙입니다.
+- 티켓 파일이 없으면 pane 생성 전에 중단해야 합니다.
+- 메인 pane은 두 agent의 `TIDD_SUMMARY`와 `TIDD_RECOMMENDATION`을 출력한 뒤 종료해야 합니다.

--- a/.codex/skills/carumuch-tidd-orchestrator/SKILL.md
+++ b/.codex/skills/carumuch-tidd-orchestrator/SKILL.md
@@ -33,7 +33,7 @@ description: Use when the user wants a TiDD-style pair of Codex helper panes in 
 - `agent-a`: 티켓 범위를 벗어나지 않는 최소 변경 구현
 - `agent-b`: 같은 티켓 범위 안에서 유지보수성까지 고려한 구현
 
-두 agent 모두 실제 개발 절차는 반드시 [carumuch-dev-cycle](/Users/yeongmujo/Desktop/Repository/carumuch-backend/.codex/skills/dev-cycle/SKILL.md)를 따릅니다.
+두 agent 모두 실제 개발 절차는 반드시 [carumuch-dev-cycle](/Users/yeongmujo/Desktop/Repository/carumuch-backend/.codex/skills/carumuch-dev-cycle/SKILL.md)를 따릅니다.
 
 ## When to Use
 
@@ -98,8 +98,8 @@ description: Use when the user wants a TiDD-style pair of Codex helper panes in 
 저장소 루트 기준 실행 예시는 아래와 같습니다.
 
 ```bash
-bash .codex/skills/tidd-orchestrator/scripts/start-tidd-orchestrator.sh 147
-bash .codex/skills/tidd-orchestrator/scripts/start-tidd-orchestrator.sh 203
+bash .codex/skills/carumuch-tidd-orchestrator/scripts/start-tidd-orchestrator.sh 147
+bash .codex/skills/carumuch-tidd-orchestrator/scripts/start-tidd-orchestrator.sh 203
 ```
 
 인자는 필수이며, 넘긴 ticket id를 그대로 브랜치 suffix로 사용합니다.

--- a/.codex/skills/carumuch-tidd-orchestrator/scripts/start-tidd-orchestrator.sh
+++ b/.codex/skills/carumuch-tidd-orchestrator/scripts/start-tidd-orchestrator.sh
@@ -1,0 +1,311 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ticket_id="${1:-}"
+
+if [[ -z "$ticket_id" ]]; then
+  echo "usage: $0 <ticket-id>" >&2
+  exit 1
+fi
+workspace="${CMUX_WORKSPACE_ID:-$(cmux current-workspace)}"
+repo_root="$(git rev-parse --show-toplevel)"
+repo_name="$(basename "$repo_root")"
+parent_dir="$(dirname "$repo_root")"
+main_surface="${CMUX_SURFACE_ID:-}"
+ticket_file="$repo_root/docs/tickets/TICKET-$ticket_id.md"
+result_timeout_sec="${TIDD_RESULT_TIMEOUT_SEC:-1800}"
+current_branch="$(git branch --show-current)"
+
+require_bin() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+surface_by_title() {
+  local title="$1"
+  cmux tree --workspace "$workspace" \
+    | awk -v title="$title" '$0 ~ "\"" title "\"" {for (i = 1; i <= NF; i++) if ($i ~ /^surface:/) {print $i; exit}}'
+}
+
+parse_field() {
+  local text="$1"
+  local prefix="$2"
+  awk -v prefix="$prefix" '{
+    for (i = 1; i <= NF; i++) {
+      if ($i ~ ("^" prefix ":")) {
+        print $i
+        exit
+      }
+    }
+  }' <<<"$text"
+}
+
+main_pane_from_surface() {
+  local surface="$1"
+  cmux tree --workspace "$workspace" | awk -v surface="$surface" '
+    /pane pane:/ {
+      for (i = 1; i <= NF; i++) if ($i ~ /^pane:/) pane = $i
+    }
+    $0 ~ surface { print pane; exit }
+  '
+}
+
+close_if_present() {
+  local title="$1"
+  local surface
+  surface="$(surface_by_title "$title" || true)"
+  if [[ -n "$surface" ]]; then
+    cmux close-surface --workspace "$workspace" --surface "$surface" >/dev/null
+  fi
+}
+
+parse_original_branch() {
+  awk -F'`' '/- 원본 브랜치:/ { print $2; exit }' "$ticket_file"
+}
+
+ensure_branch_from_develop() {
+  local branch="$1"
+
+  if ! git show-ref --verify --quiet "refs/heads/develop"; then
+    echo "develop branch not found locally" >&2
+    exit 1
+  fi
+
+  if ! git show-ref --verify --quiet "refs/heads/$branch"; then
+    git branch "$branch" develop >/dev/null
+  fi
+}
+
+wait_for_codex_ready() {
+  local surface="$1"
+  local attempt
+  local screen
+
+  for attempt in $(seq 1 30); do
+    screen="$(cmux read-screen --workspace "$workspace" --surface "$surface" --lines 60 2>/dev/null || true)"
+    if grep -Eq 'OpenAI Codex|directory:|gpt-' <<<"$screen"; then
+      return 0
+    fi
+    sleep 1
+  done
+
+  echo "codex did not become ready on $surface" >&2
+  exit 1
+}
+
+send_ticket_prompt() {
+  local surface="$1"
+  local agent_name="$2"
+  local role_instruction="$3"
+  local prompt_text
+
+  prompt_text=$(cat <<EOF
+$ticket_file 를 기준으로 작업을 시작하세요.
+
+반드시 먼저 아래를 읽으세요.
+- AGENTS.md
+- docs/architecture.md
+- docs/code-style.md
+- docs/testing-guide.md
+- $ticket_file
+- .codex/skills/dev-cycle/SKILL.md
+
+당신의 역할은 $agent_name 입니다.
+$role_instruction
+
+작업 원칙:
+- 반드시 .codex/skills/dev-cycle/SKILL.md 를 따라 개발하세요.
+- implementer -> verifier -> reviewer 순서를 지키세요.
+- verifier 단계에서는 bash scripts/verify.sh 만 실행하세요.
+- 티켓 범위를 벗어나지 마세요.
+- 변경 전 관련 코드를 먼저 읽으세요.
+- 필요한 테스트를 함께 수정하세요.
+- 최종 검증은 bash scripts/verify.sh 기준으로 설명 가능해야 합니다.
+- 작업 완료 시 마지막 메시지에 아래 두 줄을 정확히 출력하세요.
+- TIDD_SUMMARY: 한 줄 요약
+- TIDD_RECOMMENDATION: 왜 이 안을 선택할지 한 줄 추천
+
+먼저 티켓과 관련 코드 구조를 파악한 뒤, 짧은 작업 계획을 세우고 구현을 진행하세요.
+EOF
+)
+
+  cmux send --workspace "$workspace" --surface "$surface" "$prompt_text" >/dev/null
+  cmux send-key --workspace "$workspace" --surface "$surface" Enter >/dev/null
+}
+
+extract_result_field() {
+  local screen="$1"
+  local label="$2"
+  printf '%s\n' "$screen" \
+    | sed -n "s/^.*$label:[[:space:]]*//p" \
+    | tail -n 1
+}
+
+collect_agent_results() {
+  local start_ts
+  local now_ts
+  local elapsed
+  local screen
+
+  start_ts="$(date +%s)"
+
+  while :; do
+    if [[ -z "${agent_a_summary:-}" || -z "${agent_a_recommendation:-}" ]]; then
+      screen="$(cmux read-screen --workspace "$workspace" --surface "$agent_a_surface" --scrollback --lines 4000 2>/dev/null || true)"
+      [[ -n "${agent_a_summary:-}" ]] || agent_a_summary="$(extract_result_field "$screen" "TIDD_SUMMARY")"
+      [[ -n "${agent_a_recommendation:-}" ]] || agent_a_recommendation="$(extract_result_field "$screen" "TIDD_RECOMMENDATION")"
+    fi
+
+    if [[ -z "${agent_b_summary:-}" || -z "${agent_b_recommendation:-}" ]]; then
+      screen="$(cmux read-screen --workspace "$workspace" --surface "$agent_b_surface" --scrollback --lines 4000 2>/dev/null || true)"
+      [[ -n "${agent_b_summary:-}" ]] || agent_b_summary="$(extract_result_field "$screen" "TIDD_SUMMARY")"
+      [[ -n "${agent_b_recommendation:-}" ]] || agent_b_recommendation="$(extract_result_field "$screen" "TIDD_RECOMMENDATION")"
+    fi
+
+    if [[ -n "${agent_a_summary:-}" && -n "${agent_a_recommendation:-}" && -n "${agent_b_summary:-}" && -n "${agent_b_recommendation:-}" ]]; then
+      return 0
+    fi
+
+    now_ts="$(date +%s)"
+    elapsed=$((now_ts - start_ts))
+    if (( elapsed >= result_timeout_sec )); then
+      echo "timed out while waiting for agent summaries (${result_timeout_sec}s)" >&2
+      return 1
+    fi
+
+    sleep 5
+  done
+}
+
+print_final_report() {
+  printf '\n== Agent Results ==\n'
+  printf '\n[agent-a]\n'
+  printf '작업 요약: %s\n' "${agent_a_summary:-미수집}"
+  printf '추천안: %s\n' "${agent_a_recommendation:-미수집}"
+  printf '\n[agent-b]\n'
+  printf '작업 요약: %s\n' "${agent_b_summary:-미수집}"
+  printf '추천안: %s\n' "${agent_b_recommendation:-미수집}"
+}
+
+ensure_worktree() {
+  local branch="$1"
+  local path="$2"
+  local base_ref="$3"
+
+  if git worktree list --porcelain | awk -v path="$path" '
+      $1 == "worktree" { current = $2 }
+      $1 == "branch" && current == path { found = 1 }
+      END { exit(found ? 0 : 1) }
+    '; then
+    return 0
+  fi
+
+  if [[ -e "$path" ]]; then
+    echo "path exists but is not a registered worktree: $path" >&2
+    exit 1
+  fi
+
+  if git show-ref --verify --quiet "refs/heads/$branch"; then
+    git worktree add "$path" "$branch" >/dev/null
+  else
+    git worktree add -b "$branch" "$path" "$base_ref" >/dev/null
+  fi
+}
+
+require_bin cmux
+require_bin git
+require_bin codex
+
+if [[ ! -f "$ticket_file" ]]; then
+  echo "ticket file not found: $ticket_file" >&2
+  exit 1
+fi
+
+ticket_branch="$(parse_original_branch)"
+if [[ -z "$ticket_branch" ]]; then
+  echo "original branch not found in ticket: $ticket_file" >&2
+  exit 1
+fi
+
+ensure_branch_from_develop "$ticket_branch"
+
+ticket_branch_path="$parent_dir/${repo_name}-ticket-${ticket_id//\//-}"
+ensure_worktree "$ticket_branch" "$ticket_branch_path" "$ticket_branch"
+
+agent_a_branch="agent-a/$ticket_id"
+agent_b_branch="agent-b/$ticket_id"
+agent_a_path="$parent_dir/${repo_name}-agent-a-${ticket_id//\//-}"
+agent_b_path="$parent_dir/${repo_name}-agent-b-${ticket_id//\//-}"
+
+ensure_worktree "$agent_a_branch" "$agent_a_path" "$ticket_branch"
+ensure_worktree "$agent_b_branch" "$agent_b_path" "$ticket_branch"
+
+main_pane=""
+if [[ -n "$main_surface" ]]; then
+  main_pane="$(main_pane_from_surface "$main_surface" || true)"
+fi
+
+close_if_present "agent-b"
+close_if_present "agent-a"
+
+agent_a_result="$(cmux new-pane --direction right --workspace "$workspace")"
+agent_a_surface="$(parse_field "$agent_a_result" surface)"
+agent_a_pane="$(parse_field "$agent_a_result" pane)"
+
+if [[ -z "$agent_a_surface" || -z "$agent_a_pane" ]]; then
+  echo "failed to create agent-a pane" >&2
+  exit 1
+fi
+
+cmux rename-tab --workspace "$workspace" --surface "$agent_a_surface" agent-a >/dev/null
+cmux send --workspace "$workspace" --surface "$agent_a_surface" "cd \"$agent_a_path\" && codex" >/dev/null
+cmux send-key --workspace "$workspace" --surface "$agent_a_surface" Enter >/dev/null
+
+cmux focus-pane --workspace "$workspace" --pane "$agent_a_pane" >/dev/null
+
+agent_b_result="$(cmux new-pane --direction down --workspace "$workspace")"
+agent_b_surface="$(parse_field "$agent_b_result" surface)"
+agent_b_pane="$(parse_field "$agent_b_result" pane)"
+
+if [[ -z "$agent_b_surface" || -z "$agent_b_pane" ]]; then
+  echo "failed to create agent-b pane" >&2
+  exit 1
+fi
+
+cmux rename-tab --workspace "$workspace" --surface "$agent_b_surface" agent-b >/dev/null
+cmux send --workspace "$workspace" --surface "$agent_b_surface" "cd \"$agent_b_path\" && codex" >/dev/null
+cmux send-key --workspace "$workspace" --surface "$agent_b_surface" Enter >/dev/null
+
+wait_for_codex_ready "$agent_a_surface"
+wait_for_codex_ready "$agent_b_surface"
+
+send_ticket_prompt \
+  "$agent_a_surface" \
+  "agent-a" \
+  "최소한의 범위만 수정해서 티켓 요구사항을 충족하세요. 불필요한 리팩터링이나 구조 변경은 하지 마세요."
+
+send_ticket_prompt \
+  "$agent_b_surface" \
+  "agent-b" \
+  "같은 티켓 요구사항을 충족하되, 유지보수성을 향상시키는 방향으로 개선하세요. 네이밍, 계층 책임, 테스트 구조 개선은 허용되지만 티켓 범위를 넘는 기능 추가는 하지 마세요."
+
+collect_agent_results || true
+
+if [[ -n "$main_pane" ]]; then
+  cmux focus-pane --workspace "$workspace" --pane "$main_pane" >/dev/null
+fi
+
+print_final_report
+
+cmux notify \
+  --workspace "$workspace" \
+  --title "tidd-orchestrator ready" \
+  --body "current=$current_branch ticket=$ticket_branch(worktree) agent-a=$agent_a_branch(worktree) agent-b=$agent_b_branch(worktree)" >/dev/null || true
+
+echo "workspace=$workspace"
+echo "current branch=$current_branch"
+echo "ticket branch=$ticket_branch path=$ticket_branch_path"
+echo "agent-a branch=$agent_a_branch path=$agent_a_path surface=$agent_a_surface pane=$agent_a_pane"
+echo "agent-b branch=$agent_b_branch path=$agent_b_path surface=$agent_b_surface pane=$agent_b_pane"

--- a/.codex/skills/carumuch-tidd-orchestrator/scripts/start-tidd-orchestrator.sh
+++ b/.codex/skills/carumuch-tidd-orchestrator/scripts/start-tidd-orchestrator.sh
@@ -110,13 +110,13 @@ $ticket_file 를 기준으로 작업을 시작하세요.
 - docs/code-style.md
 - docs/testing-guide.md
 - $ticket_file
-- .codex/skills/dev-cycle/SKILL.md
+- .codex/skills/carumuch-dev-cycle/SKILL.md
 
 당신의 역할은 $agent_name 입니다.
 $role_instruction
 
 작업 원칙:
-- 반드시 .codex/skills/dev-cycle/SKILL.md 를 따라 개발하세요.
+- 반드시 .codex/skills/carumuch-dev-cycle/SKILL.md 를 따라 개발하세요.
 - implementer -> verifier -> reviewer 순서를 지키세요.
 - verifier 단계에서는 bash scripts/verify.sh 만 실행하세요.
 - 티켓 범위를 벗어나지 마세요.
@@ -291,7 +291,19 @@ send_ticket_prompt \
   "agent-b" \
   "같은 티켓 요구사항을 충족하되, 유지보수성을 향상시키는 방향으로 개선하세요. 네이밍, 계층 책임, 테스트 구조 개선은 허용되지만 티켓 범위를 넘는 기능 추가는 하지 마세요."
 
-collect_agent_results || true
+if ! collect_agent_results; then
+  if [[ -n "$main_pane" ]]; then
+    cmux focus-pane --workspace "$workspace" --pane "$main_pane" >/dev/null
+  fi
+
+  cmux notify \
+    --workspace "$workspace" \
+    --title "tidd-orchestrator failed" \
+    --body "failed to collect agent results within ${result_timeout_sec}s" >/dev/null || true
+
+  echo "failed to collect all agent results within timeout (${result_timeout_sec}s)" >&2
+  exit 1
+fi
 
 if [[ -n "$main_pane" ]]; then
   cmux focus-pane --workspace "$workspace" --pane "$main_pane" >/dev/null

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ docker compose -f infrastructure/docker-compose-monitoring.yml up -d
 AI Agent 개발 워크플로를 함께 사용합니다.
 
 - 저장소 규칙: `AGENTS.md`
-- 기본 개발 오케스트레이터 스킬: `.codex/skills/dev-cycle/SKILL.md`
+- 기본 개발 오케스트레이터 스킬: `.codex/skills/carumuch-dev-cycle/SKILL.md`
 - 전담 에이전트: `implementer-agent`, `verifier-agent`, `reviewer-agent`
 - 자동 훅: `.codex/hooks.json`
 


### PR DESCRIPTION
  ## 🔗 관련 이슈
  Closes #147

  ---

  ## 변경 내용
  - `cmux` 기반 병렬 에이전트 작업을 위한 TiDD orchestrator 스킬과 실행 스크립트를 추가했습니다.
  - agent 선택 후 병합, 검증, pane/worktree 정리를 수행하는 TiDD finalizer 스킬과 실행 스크립트를 추가했습니다.
  - 기존 저장소 전용 스킬 경로를 `carumuch-*` 네이밍으로 정리하고, 관련 참조 경로를 갱신했습니다.
  - `cmux` 워크스페이스 제어 명령을 반복 승인 없이 사용할 수 있도록 `.codex/rules/default.rules`에 허용 규칙을 추가했습니다.

  ---

  ## 변경 이유
  - 동일한 TiDD 티켓을 두 개의 보조 에이전트가 서로 다른 worktree/branch에서 병렬로 수행할 수 있는 작업 하네스가 필요했습니다.
  - 비교 작업 후 선택된 결과만 안전하게 핵심 티켓 브랜치에 반영하고, 생성된 pane/worktree/branch 자원을 일관되게 정리할 수 있어야 했습니다.

  ---

  ## 테스트
  - [x] 로컬 테스트 완료
  - [x] 주요 시나리오 검증 완료
  - [ ] 테스트 코드 추가/수정 완료

  ---

  ## 체크리스트
  - [x] self review 완료
  - [x] 불필요한 코드 제거 완료
  - [x] 네이밍 / 컨벤션 확인 완료

  ---
  ## 참고 사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * TiDD 기반 다중 AI 에이전트 오케스트레이션 워크플로 및 실행 스크립트 추가
  * 티켓 작업 완료를 위한 TiDD 파이널라이저(선택 병합·검증·정리 절차) 추가

* **Documentation**
  * 신규 스킬 문서 및 실행 가이드 추가(오케스트레이터·파이널라이저·운영 규칙 포함)
  * README의 오케스트레이터 경로 표기 업데이트

* **Chores**
  * 워크스페이스 제어·병렬 실행 관련 명령 허용 규칙 추가
  * 스킬 식별자명 표준화(일부 이름 업데이트)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->