### PR TITLE
[#155] 공업사 수리 이력 카운트 동시성 보호

### DIFF
--- a/src/main/java/com/carumuch/capstone/bidding/application/BiddingService.java
+++ b/src/main/java/com/carumuch/capstone/bidding/application/BiddingService.java
@@ -57,7 +57,7 @@ public class BiddingService {
         // 체결 공업사 입찰 횟수 증가
         BodyShop bodyShop = bidRepository.findByIdWithBodyShop(id)
                 .orElseThrow(() -> new CustomException(RESOURCE_NOT_FOUND)).getBodyShop();
-        bodyShop.acceptCount();
+        bodyShop.increaseAcceptCount();
 
         // 견적서를 공개에서 비공개로 전환
         Estimate estimate = estimateRepository.findById(bid.getEstimate().getId())

--- a/src/main/java/com/carumuch/capstone/bodyshop/domain/BodyShop.java
+++ b/src/main/java/com/carumuch/capstone/bodyshop/domain/BodyShop.java
@@ -43,6 +43,10 @@ public class BodyShop extends AggregateRoot<BodyShop> implements AccessPolicy {
 	@Column(name = "manager_user_id", nullable = false, updatable = false)
 	private Long managerUserId;
 
+    @Version
+    @Column(name = "version", nullable = false)
+    private Long version;
+
     public BodyShop(
 		String name,
 		Location location,
@@ -77,8 +81,7 @@ public class BodyShop extends AggregateRoot<BodyShop> implements AccessPolicy {
         this.pickupAvailable = pickupAvailability;
     }
 
-	// TODO: 원자적 연산이 아니라 동시성 문제가 우려됨, 수정 필요
-    public void acceptCount() {
+    public void increaseAcceptCount() {
         this.acceptCount += 1;
     }
 

--- a/src/main/java/com/carumuch/capstone/common/presentation/advice/ControllerExceptionAdvice.java
+++ b/src/main/java/com/carumuch/capstone/common/presentation/advice/ControllerExceptionAdvice.java
@@ -2,8 +2,10 @@ package com.carumuch.capstone.common.presentation.advice;
 
 import static org.springframework.http.HttpStatus.*;
 
+import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -11,6 +13,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import com.carumuch.capstone.common.exception.CustomException;
 import com.carumuch.capstone.common.presentation.dto.ApiErrorResponse;
 
+import jakarta.persistence.OptimisticLockException;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -30,5 +33,20 @@ public class ControllerExceptionAdvice {
 		return ResponseEntity.status(BAD_REQUEST).body(
                 ApiErrorResponse.of(e.getBindingResult().getFieldErrors())
         );
+	}
+
+	@ExceptionHandler({
+		ObjectOptimisticLockingFailureException.class,
+		OptimisticLockingFailureException.class,
+		OptimisticLockException.class
+	})
+	public ResponseEntity<ApiErrorResponse<Void>> handleOptimisticLockException(Exception e) {
+		log.warn("동시성 충돌이 발생했습니다. type=optimistic-lock, exception={}, message={}",
+			e.getClass().getSimpleName(),
+			e.getMessage(),
+			e
+		);
+		return ResponseEntity.status(CONFLICT)
+			.body(ApiErrorResponse.of("요청이 동시에 처리되어 작업을 완료하지 못했습니다. 잠시 후 다시 시도해주세요."));
 	}
 }

--- a/src/main/resources/db/migration/V206__add_body_shop_version_column.sql
+++ b/src/main/resources/db/migration/V206__add_body_shop_version_column.sql
@@ -1,0 +1,2 @@
+ALTER TABLE body_shop
+    ADD COLUMN version BIGINT NOT NULL DEFAULT 0;

--- a/src/test/java/com/carumuch/capstone/bodyshop/domain/BodyShopTest.java
+++ b/src/test/java/com/carumuch/capstone/bodyshop/domain/BodyShopTest.java
@@ -1,0 +1,20 @@
+package com.carumuch.capstone.bodyshop.domain;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.carumuch.capstone.support.fixture.BodyShopFixture;
+
+class BodyShopTest {
+
+	@Test
+	@DisplayName("수리 이력을 증가시킨다")
+	void 수리_이력을_증가시킨다() {
+		BodyShop bodyShop = BodyShopFixture.BODY_SHOP_FIXTURE_1.create(1L);
+
+		bodyShop.increaseAcceptCount();
+
+		Assertions.assertThat(bodyShop.getAcceptCount()).isEqualTo(1);
+	}
+}

--- a/src/test/java/com/carumuch/capstone/bodyshop/integration/BodyShopConcurrencyIntegrationTest.java
+++ b/src/test/java/com/carumuch/capstone/bodyshop/integration/BodyShopConcurrencyIntegrationTest.java
@@ -1,0 +1,85 @@
+package com.carumuch.capstone.bodyshop.integration;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import com.carumuch.capstone.bodyshop.domain.BodyShop;
+import com.carumuch.capstone.bodyshop.domain.BodyShopRepository;
+import com.carumuch.capstone.identity.domain.user.User;
+import com.carumuch.capstone.identity.domain.user.UserRepository;
+import com.carumuch.capstone.support.IntegrationSupportTest;
+import com.carumuch.capstone.support.fixture.BodyShopFixture;
+import com.carumuch.capstone.support.fixture.UserFixture;
+
+@DisplayName("공업사 동시성 통합 테스트")
+class BodyShopConcurrencyIntegrationTest extends IntegrationSupportTest {
+
+	@Autowired
+	BodyShopRepository bodyShopRepository;
+
+	@Autowired
+	UserRepository userRepository;
+
+	@Autowired
+	PlatformTransactionManager transactionManager;
+
+	BodyShop bodyShop;
+
+	@BeforeEach
+	void setUp() {
+		User mechanicUser = userRepository.save(UserFixture.USER_FIXTURE_2.create());
+		BodyShop bodyShopFixture = BodyShopFixture.BODY_SHOP_FIXTURE_1.create(mechanicUser.getId());
+		bodyShop = bodyShopRepository.save(
+			new BodyShop(
+				bodyShopFixture.getName(),
+				bodyShopFixture.getLocation(),
+				bodyShopFixture.getDescription(),
+				bodyShopFixture.getLink(),
+				bodyShopFixture.getPhoneNumber(),
+				bodyShopFixture.isPickupAvailable(),
+				bodyShopFixture.getManagerUserId()
+			)
+		);
+		mechanicUser.assignBodyShop(bodyShop);
+	}
+
+	@Nested
+	@DisplayName("공업사 수리 이력 증가")
+	class IncreaseAcceptCount {
+
+		@Test
+		@DirtiesContext(methodMode = DirtiesContext.MethodMode.AFTER_METHOD)
+		@Transactional(propagation = Propagation.NOT_SUPPORTED)
+		void 오래된_버전으로_수정하면_낙관적_락_예외가_발생한다() {
+			TransactionTemplate transactionTemplate = new TransactionTemplate(transactionManager);
+			Long bodyShopId = bodyShop.getId();
+
+			BodyShop staleBodyShop = transactionTemplate.execute(status ->
+				bodyShopRepository.findById(bodyShopId)
+					.orElseThrow(() -> new AssertionError("BodyShop not found"))
+			);
+
+			transactionTemplate.executeWithoutResult(status -> {
+				BodyShop currentBodyShop = bodyShopRepository.findById(bodyShopId)
+					.orElseThrow(() -> new AssertionError("BodyShop not found"));
+				currentBodyShop.increaseAcceptCount();
+			});
+
+			staleBodyShop.increaseAcceptCount();
+
+			Assertions.assertThatThrownBy(() ->
+				transactionTemplate.executeWithoutResult(status -> bodyShopRepository.save(staleBodyShop))
+			).isInstanceOf(ObjectOptimisticLockingFailureException.class);
+		}
+	}
+}

--- a/src/test/java/com/carumuch/capstone/bodyshop/integration/BodyShopIntegrationTest.java
+++ b/src/test/java/com/carumuch/capstone/bodyshop/integration/BodyShopIntegrationTest.java
@@ -8,12 +8,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.orm.ObjectOptimisticLockingFailureException;
-import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.transaction.PlatformTransactionManager;
-import org.springframework.transaction.annotation.Propagation;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.transaction.support.TransactionTemplate;
 
 import com.carumuch.capstone.bodyshop.application.BodyShopService;
 import com.carumuch.capstone.bodyshop.domain.BodyShop;
@@ -44,8 +38,6 @@ public class BodyShopIntegrationTest extends IntegrationSupportTest {
 	BodyShopRepository bodyShopRepository;
 	@Autowired
 	UserRepository userRepository;
-	@Autowired
-	PlatformTransactionManager transactionManager;
 
 	User mechanicUser;
 	User customerUser;
@@ -384,42 +376,6 @@ public class BodyShopIntegrationTest extends IntegrationSupportTest {
 				() -> Assertions.assertThat(result.content().get(0).name()).isEqualTo("송파 픽업 차케어"),
 				() -> Assertions.assertThat(result.page().totalElements()).isEqualTo(1)
 			);
-		}
-	}
-
-	@Nested
-	@DisplayName("공업사 수리 이력 증가")
-	class IncreaseAcceptCount {
-		@Test
-		void 수리_이력_증가가_저장된다() {
-			bodyShop.increaseAcceptCount();
-
-			Assertions.assertThat(bodyShop.getAcceptCount()).isEqualTo(1);
-		}
-
-		@Test
-		@DirtiesContext(methodMode = DirtiesContext.MethodMode.AFTER_METHOD)
-		@Transactional(propagation = Propagation.NOT_SUPPORTED)
-		void 오래된_버전으로_수정하면_낙관적_락_예외가_발생한다() {
-			TransactionTemplate transactionTemplate = new TransactionTemplate(transactionManager);
-			Long bodyShopId = bodyShop.getId();
-
-			BodyShop staleBodyShop = transactionTemplate.execute(status ->
-				bodyShopRepository.findById(bodyShopId)
-					.orElseThrow(() -> new AssertionError("BodyShop not found"))
-			);
-
-			transactionTemplate.executeWithoutResult(status -> {
-				BodyShop currentBodyShop = bodyShopRepository.findById(bodyShopId)
-					.orElseThrow(() -> new AssertionError("BodyShop not found"));
-				currentBodyShop.increaseAcceptCount();
-			});
-
-			staleBodyShop.increaseAcceptCount();
-
-			Assertions.assertThatThrownBy(() ->
-				transactionTemplate.executeWithoutResult(status -> bodyShopRepository.save(staleBodyShop))
-			).isInstanceOf(ObjectOptimisticLockingFailureException.class);
 		}
 	}
 

--- a/src/test/java/com/carumuch/capstone/bodyshop/integration/BodyShopIntegrationTest.java
+++ b/src/test/java/com/carumuch/capstone/bodyshop/integration/BodyShopIntegrationTest.java
@@ -8,6 +8,12 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import com.carumuch.capstone.bodyshop.application.BodyShopService;
 import com.carumuch.capstone.bodyshop.domain.BodyShop;
@@ -38,6 +44,8 @@ public class BodyShopIntegrationTest extends IntegrationSupportTest {
 	BodyShopRepository bodyShopRepository;
 	@Autowired
 	UserRepository userRepository;
+	@Autowired
+	PlatformTransactionManager transactionManager;
 
 	User mechanicUser;
 	User customerUser;
@@ -376,6 +384,42 @@ public class BodyShopIntegrationTest extends IntegrationSupportTest {
 				() -> Assertions.assertThat(result.content().get(0).name()).isEqualTo("송파 픽업 차케어"),
 				() -> Assertions.assertThat(result.page().totalElements()).isEqualTo(1)
 			);
+		}
+	}
+
+	@Nested
+	@DisplayName("공업사 수리 이력 증가")
+	class IncreaseAcceptCount {
+		@Test
+		void 수리_이력_증가가_저장된다() {
+			bodyShop.increaseAcceptCount();
+
+			Assertions.assertThat(bodyShop.getAcceptCount()).isEqualTo(1);
+		}
+
+		@Test
+		@DirtiesContext(methodMode = DirtiesContext.MethodMode.AFTER_METHOD)
+		@Transactional(propagation = Propagation.NOT_SUPPORTED)
+		void 오래된_버전으로_수정하면_낙관적_락_예외가_발생한다() {
+			TransactionTemplate transactionTemplate = new TransactionTemplate(transactionManager);
+			Long bodyShopId = bodyShop.getId();
+
+			BodyShop staleBodyShop = transactionTemplate.execute(status ->
+				bodyShopRepository.findById(bodyShopId)
+					.orElseThrow(() -> new AssertionError("BodyShop not found"))
+			);
+
+			transactionTemplate.executeWithoutResult(status -> {
+				BodyShop currentBodyShop = bodyShopRepository.findById(bodyShopId)
+					.orElseThrow(() -> new AssertionError("BodyShop not found"));
+				currentBodyShop.increaseAcceptCount();
+			});
+
+			staleBodyShop.increaseAcceptCount();
+
+			Assertions.assertThatThrownBy(() ->
+				transactionTemplate.executeWithoutResult(status -> bodyShopRepository.save(staleBodyShop))
+			).isInstanceOf(ObjectOptimisticLockingFailureException.class);
 		}
 	}
 


### PR DESCRIPTION
## 🔗 관련 이슈
Refs #155

---

## 변경 내용
  - `BodyShop`에 `@Version` 필드를 추가하고 `body_shop.version` 컬럼 마이그레이션을 추가했습니다.
  - 공업사 수리 이력 증가 메서드를 `acceptCount()`에서 `increaseAcceptCount()`로 변경해 의도를 명확히 했습니다.
  - 입찰 체결 시 공업사 수리 이력 증가 로직이 새 메서드를 사용하도록 반영했습니다.
  - 공업사 수리 이력 증가 도메인 테스트와, 오래된 버전 저장 시 낙관적 락 예외가 발생하는 통합 테스트를 추가했습니다.

---

## 변경 이유
  - 공업사 수리 이력(`acceptCount`) 증가는 입찰 체결 시 함께 갱신되는 값이라 동시 요청이 겹치면 정합성 문제가 생길 수 있습니다.
  - 이번 변경은 낙관적 락으로 오래된 엔티티 저장을 감지해, 동시성 상황에서 잘못된 카운트 반영을 방지하기 위한 목적입니다.

---

## 테스트
- [x] 로컬 테스트 완료 
- [x] 주요 시나리오 검증 완료
- [x] 테스트 코드 추가/수정 완료

---

## 체크리스트
- [x] self review 완료
- [x] 불필요한 코드 제거 완료
- [x] 네이밍 / 컨벤션 확인 완료

---
## 참고 사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 입찰 체결 시 수리 업체의 체결 횟수 증가 로직을 개선했습니다.
  * 동시성 충돌 시 잘못된 횟수 반영을 방지하도록 처리 흐름을 보강했습니다.
* **테스트**
  * 체결 횟수 증가 동작을 검증하는 단위 테스트를 추가했습니다.
  * 동시성 상황에서 낙관적 락 충돌이 발생하는지 검증하는 통합 테스트를 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->